### PR TITLE
Refactor event service to use constants and env

### DIFF
--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -4,22 +4,22 @@ RSpec.describe EventService do
   subject { described_class.new(request) }
 
   it 'sends request_started event' do
-    expect(subject).to receive(:send_event).with('request_started', hash_including(:request_id))
+    expect(subject).to receive(:send_event).with(described_class::EVENT_REQUEST_STARTED, hash_including(:request_id))
     subject.request_started
   end
 
   it 'sends request_finished event' do
-    expect(subject).to receive(:send_event).with('request_finished', hash_including(:request_id, :decision, :comments))
+    expect(subject).to receive(:send_event).with(described_class::EVENT_REQUEST_FINISHED, hash_including(:request_id, :decision, :comments))
     subject.request_finished
   end
 
   it 'sends approver_group_notified event' do
-    expect(subject).to receive(:send_event).with('approver_group_notified', hash_including(:request_id, :group_name))
+    expect(subject).to receive(:send_event).with(described_class::EVENT_APPROVER_GROUP_NOTIFIED, hash_including(:request_id, :group_name))
     subject.approver_group_notified(stage)
   end
 
   it 'sends approver_group_finished event' do
-    expect(subject).to receive(:send_event).with('approver_group_finished', hash_including(:request_id, :group_name, :decision, :comments))
+    expect(subject).to receive(:send_event).with(described_class::EVENT_APPROVER_GROUP_FINISHED, hash_including(:request_id, :group_name, :decision, :comments))
     subject.approver_group_finished(stage)
   end
 end


### PR DESCRIPTION
Allow to set Kafka topic through `ENV['KAFKA_TOPIC']`

Some refactoring to use constants. 