### PR TITLE
Changed to used params.require to get attributes

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -18,7 +18,7 @@ class AdminsController < ApplicationController
   end
 
   def add_stage
-    req = Request.find(params[:request_id])
+    req = Request.find(params.require(:request_id))
     stage = req.stages.create!(stage_params)
 
     json_response(stage, :created)
@@ -30,12 +30,12 @@ class AdminsController < ApplicationController
   end
 
   def add_workflow
-    workflow = Template.find(params[:template_id]).workflows.create!(workflow_params)
+    workflow = Template.find(params.require(:template_id)).workflows.create!(workflow_params)
     json_response(workflow, :created)
   end
 
   def fetch_group_by_id
-    group = Group.find(params[:id])
+    group = Group.find(params.require(:id))
 
     json_response(group)
   end
@@ -59,12 +59,12 @@ class AdminsController < ApplicationController
   end
 
   def fetch_template_by_id
-    template = Template.find(params[:id])
+    template = Template.find(params.require(:id))
     json_response(template)
   end
 
   def fetch_template_workflows
-    template = Template.find(params[:template_id])
+    template = Template.find(params.require(:template_id))
     json_response(template.workflows)
   end
 
@@ -74,13 +74,13 @@ class AdminsController < ApplicationController
   end
 
   def fetch_workflow_by_id
-    workflow = Workflow.find(params[:id])
+    workflow = Workflow.find(params.require(:id))
 
     json_response(workflow)
   end
 
   def fetch_workflow_requests
-    workflow = Workflow.find(params[:workflow_id])
+    workflow = Workflow.find(params.require(:workflow_id))
 
     json_response(workflow.requests)
   end
@@ -92,47 +92,47 @@ class AdminsController < ApplicationController
   end
 
   def remove_group
-    Group.find(params[:id]).destroy
+    Group.find(params.require(:id)).destroy
     head :no_content
   end
 
   def remove_request
-    Request.find(params[:id]).destroy
+    Request.find(params.require(:id)).destroy
     head :no_content
   end
 
   def remove_stage
-    Stage.find(params[:id]).destroy
+    Stage.find(params.require(:id)).destroy
     head :no_content
   end
 
   def remove_template
-    Template.find(params[:id]).destroy
+    Template.find(params.require(:id)).destroy
   end
 
   def remove_workflow
-    Workflow.find(params[:id]).destroy
+    Workflow.find(params.require(:id)).destroy
 
     head :no_content
   end
 
   def update_group
-    Group.find(params[:id]).update(group_params)
+    Group.find(params.require(:id)).update(group_params)
     head :no_content
   end
 
   def update_request
-    RequestUpdateService.new(params[:id]).update(request_params)
+    RequestUpdateService.new(params.require(:id)).update(request_params)
     head :no_content
   end
 
   def update_template
-    Template.find(params[:id]).update(template_params)
+    Template.find(params.require(:id)).update(template_params)
     head :no_content
   end
 
   def update_workflow
-    Workflow.find(params[:id]).update(workflow_params)
+    Workflow.find(params.require(:id)).update(workflow_params)
 
     head :no_content
   end

--- a/app/controllers/mixins/approver_operations_mixin.rb
+++ b/app/controllers/mixins/approver_operations_mixin.rb
@@ -2,14 +2,14 @@ module ApproverOperationsMixin
   extend ActiveSupport::Concern
 
   def add_action
-    stage = Stage.find(params[:stage_id])
+    stage = Stage.find(params.require(:stage_id))
     action = stage.actions.create!(action_params)
 
     json_response(action, :created)
   end
 
   def fetch_action_by_id
-    action = Action.find(params[:id])
+    action = Action.find(params.require(:id))
 
     json_response(action)
   end
@@ -21,25 +21,25 @@ module ApproverOperationsMixin
   end
 
   def fetch_stage_by_id
-    stage = Stage.find(params[:id])
+    stage = Stage.find(params.require(:id))
 
     json_response(stage)
   end
 
   def remove_action
-    Action.find(params[:id]).destroy
+    Action.find(params.require(:id)).destroy
 
     head :no_content
   end
 
   def update_action
-    Action.find(params[:id]).update(action_params)
+    Action.find(params.require(:id)).update(action_params)
 
     head :no_content
   end
 
   def update_stage
-    StageUpdateService.new(params[:id]).update(stage_params)
+    StageUpdateService.new(params.require(:id)).update(stage_params)
     head :no_content
   end
 

--- a/app/controllers/mixins/user_operations_mixin.rb
+++ b/app/controllers/mixins/user_operations_mixin.rb
@@ -2,17 +2,17 @@ module UserOperationsMixin
   extend ActiveSupport::Concern
 
   def add_request
-    req = RequestCreateService.new(params[:workflow_id]).create(request_params)
+    req = RequestCreateService.new(params.require(:workflow_id)).create(request_params)
     json_response(req, :created)
   end
 
   def fetch_request_by_id
-    req = Request.find(params[:id])
+    req = Request.find(params.require(:id))
     json_response(req)
   end
 
   def fetch_request_stages
-    req = Request.find(params[:request_id])
+    req = Request.find(params.require(:request_id))
 
     json_response(req.stages)
   end


### PR DESCRIPTION
Use params.require to ensure the parameter exists, otherwise will raise an **ActionController::ParameterMissing** error.