### PR TITLE
Removed duplicate group_id in stage definition in swagger yaml

### DIFF
--- a/public/doc/swagger-2.yaml
+++ b/public/doc/swagger-2.yaml
@@ -858,8 +858,6 @@ definitions:
       id:
         type: string
         readOnly: true
-      group_id:
-        type: integer
       state:
         $ref: '#/definitions/State'
       decision:


### PR DESCRIPTION
This PR removed duplicate group_id definition from stage.

Related JIRA ticket: https://projects.engineering.redhat.com/secure/RapidBoard.jspa?rapidView=2404&projectKey=SSP&view=detail&selectedIssue=SSP-113