### PR TITLE
Make use of APP_NAME and PATH_PREFIX environment variables

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
 
   def add_swagger_route http_method, path, opts = {}
     prefix = "api"
-    prefix = "#{ENV["PATH_PREFIX"]}/#{ENV["APP_NAME"]}" if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
+    if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
+      prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
+    end
 
     full_path = path.gsub(/{(.*?)}/, ':\1')
     scope :as => :api, :module => "api", :path => prefix do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,10 +13,12 @@ Rails.application.routes.draw do
   mount SwaggerUiEngine::Engine, :at => '/open-api'
 
   def add_swagger_route http_method, path, opts = {}
+    prefix = "api"
+    prefix = "#{ENV["PATH_PREFIX"]}/#{ENV["APP_NAME"]}" if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
+
     full_path = path.gsub(/{(.*?)}/, ':\1')
-    namespace :api do
+    scope :as => :api, :module => "api", :path => prefix do
       namespace :v0x0, :path => "v0.0" do
-        full_path = File.join(ENV["BASE_PATH"], full_path) if ENV["BASE_PATH"]
         constraint = opts[:constraint_name].camelize.constantize
         match full_path, :to => "#{opts.fetch(:controller_name)}##{opts[:action_name]}", :constraints => constraint, :via => http_method
       end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -18,6 +18,14 @@ describe "Swagger stuff" do
         expect(api_v0x0_requests_url(:only_path => true)).to eq("/#{URI.encode(ENV["PATH_PREFIX"])}/#{URI.encode(ENV["APP_NAME"])}/v0.0/requests")
       end
 
+      it "with extra slashes" do
+        ENV["PATH_PREFIX"] = "//example/path/prefix/"
+        ENV["APP_NAME"] = "/appname/"
+        Rails.application.reload_routes!
+
+        expect(api_v0x0_requests_url(:only_path => true)).to eq("/example/path/prefix/appname/v0.0/requests")
+      end
+
       it "doesn't use the APP_NAME when PATH_PREFIX is empty" do
         ENV["PATH_PREFIX"] = ""
         Rails.application.reload_routes!

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -1,0 +1,42 @@
+describe "Swagger stuff" do
+  describe "Routing" do
+    include Rails.application.routes.url_helpers
+
+    context "customizable route prefixes" do
+      before do
+        stub_const("ENV", ENV.to_h.merge("PATH_PREFIX" => random_path, "APP_NAME" => random_path_part))
+        Rails.application.reload_routes!
+      end
+
+      after(:all) do
+        Rails.application.reload_routes!
+      end
+
+      it "with a random prefix" do
+        expect(ENV["PATH_PREFIX"]).not_to be_nil
+        expect(ENV["APP_NAME"]).not_to be_nil
+        expect(api_v0x0_requests_url(:only_path => true)).to eq("/#{URI.encode(ENV["PATH_PREFIX"])}/#{URI.encode(ENV["APP_NAME"])}/v0.0/requests")
+      end
+
+      it "doesn't use the APP_NAME when PATH_PREFIX is empty" do
+        ENV["PATH_PREFIX"] = ""
+        Rails.application.reload_routes!
+
+        expect(ENV["APP_NAME"]).not_to be_nil
+        expect(api_v0x0_requests_url(:only_path => true)).to eq("/api/v0.0/requests")
+      end
+    end
+
+    def words
+      @words ||= File.readlines("/usr/share/dict/words").collect(&:strip)
+    end
+
+    def random_path_part
+      rand(1..5).times.collect { words.sample }.join("_")
+    end
+
+    def random_path
+      rand(1..10).times.collect { random_path_part }.join("/")
+    end
+  end
+end


### PR DESCRIPTION
Similar change to what was done in the service-portal-api https://github.com/ManageIQ/service_portal-api/pull/65

For example:

APP_NAME = approval
PATH_PREFIX = ""
Requests Path = /api/v0.0/requests

APP_NAME = approval
PATH_PREFIX = foo/bar
Requests Path = /foo/bar/approval/v0.0/requests