### PR TITLE
Validate whether an action is allowed at current statge state

### DIFF
--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -51,16 +51,16 @@ class RequestCreateService
     acs = ActionCreateService.new(stage.id)
     sleep(sleep_time)
     acs.create(
-      :operation    => Action::NOTIFY_OPERATION,
-      :processed_by => 'system',
-      :comments     => "email sent to #{stage.group.contact_setting}"
+      'operation'    => Action::NOTIFY_OPERATION,
+      'processed_by' => 'system',
+      'comments'     => "email sent to #{stage.group.contact_setting}"
     )
 
     sleep(sleep_time)
     acs.create(
-      :operation    => Action::APPROVE_OPERATION,
-      :processed_by => stage.group.contact_setting,
-      :comments     => 'ok'
+      'operation'    => Action::APPROVE_OPERATION,
+      'processed_by' => stage.group.contact_setting,
+      'comments'     => 'ok'
     )
   end
 

--- a/config/initializers/load_extensions.rb
+++ b/config/initializers/load_extensions.rb
@@ -1,3 +1,4 @@
 require 'admins_constraints'
 require 'users_constraints'
 require 'approvers_constraints'
+require 'exceptions'

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class ApprovalError < StandardError; end
+end


### PR DESCRIPTION
Allowed state transition through action:
pending -> notify -> notified
notified -> approve/deny -> finished
pending -> skip -> skipped
memo action is always allowed.

Raise an error if not one of above cases. 