### PR TITLE
Use manageiq-api-common for logging and metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,11 @@ gem 'pg',                 '~> 1.0', :require => false
 gem 'prometheus-client',  '~> 0.8.0'
 gem 'puma',               '~> 3.0'
 gem 'rack-cors',          '>= 0.4.1'
-gem 'rails',              '~> 5.1.6.1'
+gem 'rails',              '~> 5.2.2'
 gem 'rest-client',        '>= 1.8.0'
 gem 'swagger_ui_engine'
+
+gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
 
 group :development, :test do
   gem 'simplecov'

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,9 +16,6 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require 'prometheus/middleware/collector'
-require 'prometheus/middleware/exporter'
-
 module ServiceApproval
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -32,15 +29,7 @@ module ServiceApproval
 
     config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
 
-    require 'manageiq/loggers'
-    config.logger = if Rails.env.production?
-                      config.colorize_logging = false
-                      ManageIQ::Loggers::Container.new
-                    else
-                      ManageIQ::Loggers::Base.new(Rails.root.join("log", "#{Rails.env}.log"))
-                    end
-
-    config.middleware.use(Prometheus::Middleware::Collector)
-    config.middleware.use(Prometheus::Middleware::Exporter)
+    ManageIQ::API::Common::Logging.activate(config)
+    ManageIQ::API::Common::Metrics.activate(config, "approval_api")
   end
 end


### PR DESCRIPTION
This also requires us to upgrade to rails 5.2.2 in order to bundle with the manageiq-api-common gem.

@bzwei @gmcculloug please review