### PR TITLE
Automatically move to next stage if no external process is configured

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -8,8 +8,7 @@ class Template < ApplicationRecord
   def self.seed
     template = find_or_create_by!(:title => 'Basic')
     template.update_attributes(
-      :description => 'A basic approval workflow that supports multi-level approver groups through email notification',
-      :ext_ref     => 'containers/ApprovalService/processes/BasicEmail'
+      :description => 'A basic approval workflow that supports multi-level approver groups through email notification'
     )
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -23,4 +23,8 @@ class Workflow < ApplicationRecord
     { :name => 'Always approve', :template => nil }
   end
   private_class_method :default_workflow_query
+
+  def external_processing?
+    template.process_setting.present?
+  end
 end

--- a/app/services/action_create_service.rb
+++ b/app/services/action_create_service.rb
@@ -18,6 +18,7 @@ class ActionCreateService
   private
 
   def validate_operation(options)
+    options = HashWithIndifferentAccess.new(options)
     operation = options['operation']
     raise Exceptions::ApprovalError, "Invalid operation: #{operation}" unless Action::OPERATIONS.include?(operation)
     send(operation, options['comments'])

--- a/app/services/stage_update_service.rb
+++ b/app/services/stage_update_service.rb
@@ -15,6 +15,7 @@ class StageUpdateService
       EventService.new(stage.request).approver_group_notified(stage)
     when Stage::FINISHED_STATE
       EventService.new(stage.request).approver_group_finished(stage)
+      stage_finished(stage.decision) unless external_processing?
       request_finished(stage.decision, stage.reason) if last_stage?
     when Stage::SKIPPED_STATE
       last_stage_skipped if last_stage?
@@ -29,6 +30,10 @@ class StageUpdateService
 
   def last_stage?
     stage.id == stage.request.stages.last.id
+  end
+
+  def external_processing?
+    stage.request.workflow.external_processing?
   end
 
   def last_stage_skipped
@@ -54,5 +59,13 @@ class StageUpdateService
       :decision => last_decision,
       :reason   => last_reason
     )
+  end
+
+  def stage_finished(decision)
+    next_stage = stage.request.stages.find { |s| s.state == Stage::PENDING_STATE }
+    return unless next_stage
+
+    operation = decision == Stage::DENIED_STATUS ? Action::SKIP_OPERATION : Action::NOTIFY_OPERATION
+    ActionCreateService.new(next_stage.id).create(:operation => operation, :processed_by => 'system')
   end
 end

--- a/db/migrate/20190118184631_add_process_setting_to_templates.rb
+++ b/db/migrate/20190118184631_add_process_setting_to_templates.rb
@@ -1,0 +1,7 @@
+class AddProcessSettingToTemplates < ActiveRecord::Migration[5.1]
+  def change
+    add_column    :templates, :process_setting, :jsonb
+    add_column    :templates, :signal_setting,  :jsonb
+    remove_column :templates, :ext_ref,         :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_08_182012) do
+ActiveRecord::Schema.define(version: 2019_01_18_184631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,10 +84,11 @@ ActiveRecord::Schema.define(version: 2019_01_08_182012) do
   create_table "templates", force: :cascade do |t|
     t.string "title"
     t.string "description"
-    t.string "ext_ref"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
+    t.jsonb "process_setting"
+    t.jsonb "signal_setting"
     t.index ["tenant_id"], name: "index_templates_on_tenant_id"
   end
 

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'Requests API' do
   # Initialize the test data
   let!(:template) { create(:template) }
-  let!(:workflow) { create(:workflow, :template_id => template.id) }
+  let!(:workflow) { create(:workflow, :name => 'Always approve') } #:template_id => template.id) }
   let(:workflow_id) { workflow.id }
   let!(:requests) { create_list(:request, 2, :workflow_id => workflow.id) }
   let(:id) { requests.first.id }
@@ -113,7 +113,12 @@ RSpec.describe 'Requests API' do
     let(:valid_attributes) { { :requester => '1234', :name => 'Visit Narnia', :content => JSON.generate(item) } }
 
     context 'when request attributes are valid' do
-      before { post "#{api_version}/workflows/#{workflow_id}/requests", :params => valid_attributes }
+      before do
+        ENV['AUTO_APPROVAL'] = 'y'
+        post "#{api_version}/workflows/#{workflow_id}/requests", :params => valid_attributes
+      end
+
+      after { ENV['AUTO_APPROVAL'] = nil }
 
       it 'returns status code 201' do
         expect(response).to have_http_status(201)

--- a/spec/services/action_create_service_spec.rb
+++ b/spec/services/action_create_service_spec.rb
@@ -51,12 +51,10 @@ RSpec.describe ActionCreateService do
     it 'updates stage and request' do
       stage1.update_attributes(:state => Stage::NOTIFIED_STATE)
       action1 = svc1.create('operation' => Action::DENY_OPERATION, 'processed_by' => 'man', 'comments' => 'bad')
-      action2 = svc2.create('operation' => Action::SKIP_OPERATION, 'processed_by' => 'sys', 'comments' => 'nop')
       stage1.reload
       stage2.reload
       request.reload
       expect(action1).to  have_attributes(:operation => Action::DENY_OPERATION, :processed_by => 'man', :comments => 'bad')
-      expect(action2).to  have_attributes(:operation => Action::SKIP_OPERATION, :processed_by => 'sys', :comments => 'nop')
       expect(stage1).to  have_attributes(:state => Stage::FINISHED_STATE, :decision => Stage::DENIED_STATUS, :reason => 'bad')
       expect(stage2).to  have_attributes(:state => Stage::SKIPPED_STATE,  :decision => Stage::UNDECIDED_STATUS, :reason => nil)
       expect(request).to have_attributes(:state => Stage::FINISHED_STATE, :decision => Stage::DENIED_STATUS, :reason => 'bad')


### PR DESCRIPTION
Add columns to store configuration how to connect to a business process engine such as BPM. If no such engine is configured, approval service will automatically move to next stage so that the approvers can still work on a request.