### PR TITLE
Use the entrypoint script to set env vars and run_rails_server in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,12 @@ RUN source /opt/rh/rh-postgresql10/enable && \
 
 COPY . $WORKDIR
 COPY docker-assets/entrypoint /usr/bin
+COPY docker-assets/run_rails_server /usr/bin
 
 RUN chgrp -R 0 $WORKDIR && \
     chmod -R g=u $WORKDIR
 
 EXPOSE 3000
 
-CMD ["entrypoint"]
+ENTRYPOINT ["entrypoint"]
+CMD ["run_rails_server"]

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-export RAILS_ENV=production
+function urlescape() {
+  PAYLOAD="$1" ruby -rcgi -e "puts CGI.escape(ENV['PAYLOAD'])"
+}
 
-bundle exec rake db:migrate db:seed
-bundle exec rails server
+safeuser=$(urlescape ${DATABASE_USER})
+safepass=$(urlescape ${DATABASE_PASSWORD})
+
+export RAILS_ENV=production
+export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/approval_production?encoding=utf8&pool=5&wait_timeout=5"
+
+exec ${@}

--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle exec rake db:migrate db:seed
+bundle exec rails server


### PR DESCRIPTION
This allows us to share environment variables in a sane way between
the CMD and users who may get a separate console session into a
running container.

This also provides a place for us to put the definition of
DATABASE_URL as it won't live in the database secret in production