### PR TITLE
Add process_ref to requests table

### DIFF
--- a/db/migrate/20190315153513_add_process_ref_to_requests.rb
+++ b/db/migrate/20190315153513_add_process_ref_to_requests.rb
@@ -1,0 +1,5 @@
+class AddProcessRefToRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_column :requests, :process_ref, :string
+  end
+end


### PR DESCRIPTION
We need this column to store process_instance_id from BPM per request.