### PR TITLE
Start or signal a business process through kie_client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'rails',              '>= 5.2.2.1', '~> 5.2.2'
 gem 'rest-client',        '>= 1.8.0'
 gem 'swagger_ui_engine'
 
+gem 'kie_client', :git => "https://github.com/ManageIQ/kie-api-client-ruby", :branch => "master"
 gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
 gem 'rbac-api-client', :git => "https://github.com/mkanoor/rbac_api_client", :branch => "master"
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -25,4 +25,8 @@ class Workflow < ApplicationRecord
   def external_processing?
     template.process_setting.present?
   end
+
+  def external_signal?
+    template.signal_setting.present?
+  end
 end

--- a/app/services/jbpm_process_service.rb
+++ b/app/services/jbpm_process_service.rb
@@ -1,0 +1,37 @@
+class JbpmProcessService
+  attr_accessor :request
+
+  def initialize(request)
+    self.request = request
+  end
+
+  def start
+    options = template.process_setting
+    Kie::Service.call(KieClient::ProcessInstancesBPMApi, options) do |bpm|
+      bpm.start_process(options['container_id'], options['process_id'], :body => process_options)
+    end
+  end
+
+  def signal(decision)
+    options = template.signal_setting
+    Kie::Service.call(KieClient::ProcessInstancesBPMApi, options) do |bpm|
+      bpm.signal_process_instance(options['container_id'], request.process_ref, options['signal_name'], :body => signal_options(decision))
+    end
+  end
+
+  private
+
+  def template
+    request.workflow.template
+  end
+
+  def process_options
+    # TODO: more options
+    request.content
+  end
+
+  def signal_options(decision)
+    # TODO: more options
+    {'decision' => decision}
+  end
+end

--- a/app/services/stage_update_service.rb
+++ b/app/services/stage_update_service.rb
@@ -11,11 +11,10 @@ class StageUpdateService
     return if old_state == stage.state
     case stage.state
     when Stage::NOTIFIED_STATE
-      request_started if first_stage?
       EventService.new(stage.request).approver_group_notified(stage)
     when Stage::FINISHED_STATE
       EventService.new(stage.request).approver_group_finished(stage)
-      stage_finished(stage.decision) unless external_processing?
+      stage_finished(stage.decision)
       request_finished(stage.decision, stage.reason) if last_stage?
     when Stage::SKIPPED_STATE
       last_stage_skipped if last_stage?
@@ -24,16 +23,16 @@ class StageUpdateService
 
   private
 
-  def first_stage?
-    stage.id == stage.request.stages.first.id
-  end
-
   def last_stage?
     stage.id == stage.request.stages.last.id
   end
 
   def external_processing?
     stage.request.workflow.external_processing?
+  end
+
+  def external_signal?
+    stage.request.workflow.external_signal?
   end
 
   def last_stage_skipped
@@ -47,12 +46,6 @@ class StageUpdateService
     request_finished(last_decision, last_reason)
   end
 
-  def request_started
-    RequestUpdateService.new(stage.request.id).update(
-      :state    => Request::NOTIFIED_STATE
-    )
-  end
-
   def request_finished(last_decision, last_reason)
     RequestUpdateService.new(stage.request.id).update(
       :state    => Request::FINISHED_STATE,
@@ -62,10 +55,24 @@ class StageUpdateService
   end
 
   def stage_finished(decision)
+    if external_signal?
+      signal_external_approval_process(decision)
+    else
+      auto_next_stage(decision)
+    end
+  end
+
+  def auto_next_stage(decision)
     next_stage = stage.request.stages.find { |s| s.state == Stage::PENDING_STATE }
     return unless next_stage
 
     operation = decision == Stage::DENIED_STATUS ? Action::SKIP_OPERATION : Action::NOTIFY_OPERATION
     ActionCreateService.new(next_stage.id).create(:operation => operation, :processed_by => 'system')
+  end
+
+  def signal_external_approval_process(decision)
+    template = stage.request.workflow.template
+    processor_class = "#{template.signal_setting['processor_type']}_process_service".classify.constantize
+    processor_class.new(stage.request).signal(decision)
   end
 end

--- a/config/initializers/load_extensions.rb
+++ b/config/initializers/load_extensions.rb
@@ -1,2 +1,3 @@
 require 'exceptions'
 require 'rbac/service'
+require 'kie/service'

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -2,4 +2,5 @@ module Exceptions
   class ApprovalError < StandardError; end
   class NoTenantError < StandardError; end
   class RBACError < StandardError; end
+  class KieError < StandardError; end
 end

--- a/lib/kie/service.rb
+++ b/lib/kie/service.rb
@@ -1,0 +1,28 @@
+require 'kie_client'
+module Kie
+  class Service
+    def self.call(klass, options)
+      setup(options)
+      yield init(klass)
+    rescue KieClient::ApiError => err
+      Rails.logger.error("KieClient::ApiError #{err.message} ")
+      raise Exceptions::KieError, err.message
+    end
+
+    private_class_method def self.setup(options)
+      KieClient.configure do |config|
+        config.host      = options['host'] || 'localhost'
+        config.scheme    = options['host'].try(:scheme) || 'http'
+        config.username  = options['username']
+        config.password  = options['password']
+        config.base_path = options['base_path'] if options['base_path']
+      end
+    end
+
+    private_class_method def self.init(klass)
+      klass.new.tap do |api|
+        api.api_client.default_headers['Authorization'] = KieClient.configure.basic_auth_token
+      end
+    end
+  end
+end

--- a/spec/services/action_create_service_spec.rb
+++ b/spec/services/action_create_service_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe ActionCreateService do
       request.reload
       expect(action).to have_attributes(:operation => Action::NOTIFY_OPERATION, :processed_by => 'system')
       expect(stage1.state).to  eq(Stage::NOTIFIED_STATE)
-      expect(request.state).to eq(Request::NOTIFIED_STATE)
     end
   end
 

--- a/spec/services/jbpm_process_service_spec.rb
+++ b/spec/services/jbpm_process_service_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe JbpmProcessService do
+  let(:common_setting) do
+    {'processor_type' => 'jbpm', 'host' => 'http://url', 'username' => 'u', 'password' => 'p', 'container_id' => 'can'}
+  end
+
+  let(:template) do
+    create(
+      :template,
+      :process_setting => common_setting.merge('process_id' => 'proc'),
+      :signal_setting  => common_setting.merge('signal_name'  => 'sig'),
+    )
+  end
+
+  let(:workflow) { create(:workflow, :template => template) }
+  let(:request)  { create(:request, :workflow => workflow) }
+  subject { described_class.new(request) }
+
+  let(:jbpm) { double(:jbpm, :api_client => double(:default_headers => {})) }
+
+  before do
+    allow(KieClient::ProcessInstancesBPMApi).to receive(:new).and_return(jbpm)
+  end
+
+  it 'starts a business process' do
+    expect(jbpm).to receive(:start_process).with('can', 'proc', hash_including(:body))
+    subject.start
+  end
+
+  it 'sends a signal to a business process' do
+    request.update_attributes(:process_ref => '100')
+    expect(jbpm).to receive(:signal_process_instance).with('can', '100', 'sig', hash_including(:body))
+    subject.signal('approved')
+  end
+end

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -8,17 +8,19 @@ RSpec.describe RequestCreateService do
 
   context 'without auto approval' do
     context 'template has external process' do
-      let(:template) { create(:template, :process_setting => {'url' => 'url'}) }
+      let(:template) { create(:template, :process_setting => {'processor_type' => 'jbpm', 'url' => 'url'}) }
 
-      it 'creates a request in pending state' do
+      it 'creates a request and immediately starts' do
+        expect(JbpmProcessService).to receive(:new).and_return(double(:jbpm, :start => 100))
         request = subject.create(:name => 'req1', :requester => 'test', :content => 'test me')
         request.reload
         expect(request).to have_attributes(
-          :name      => 'req1',
-          :requester => 'test',
-          :content   => 'test me',
-          :state     => Request::PENDING_STATE,
-          :decision  => Request::UNDECIDED_STATUS
+          :name        => 'req1',
+          :requester   => 'test',
+          :content     => 'test me',
+          :process_ref => '100',
+          :state       => Request::NOTIFIED_STATE,
+          :decision    => Request::UNDECIDED_STATUS
         )
       end
     end


### PR DESCRIPTION
When the `process_setting` and `signal_setting` are configured for a template to connect to an external jbpm kieserver, the code now creates a new process instance when a request is created, and signals the instance when a stage is completed.

