### PR TITLE
Add context column to Request model

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -17,4 +17,12 @@ class Request < ApplicationRecord
   scope :decision,  ->(decision)  { where(:decision => decision) }
   scope :state,     ->(state)     { where(:state => state) }
   scope :requester, ->(requester) { where(:requester => requester) }
+
+  after_initialize :set_context
+
+  private
+
+  def set_context
+    self.context = ManageIQ::API::Common::Request.current.to_h
+  end
 end

--- a/db/migrate/20190402165411_add_context_to_request.rb
+++ b/db/migrate/20190402165411_add_context_to_request.rb
@@ -1,0 +1,5 @@
+class AddContextToRequest < ActiveRecord::Migration[5.2]
+  def change
+    add_column :requests, :context, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_29_151023) do
+ActiveRecord::Schema.define(version: 2019_04_02_165411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_03_29_151023) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.string "process_ref"
+    t.jsonb "context"
     t.index ["tenant_id"], name: "index_requests_on_tenant_id"
     t.index ["workflow_id"], name: "index_requests_on_workflow_id"
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-263

Adding a `context` column to the Request object so we can track how things move through the system. It just stores the `ManageIQ::API::Common::Request.current` object - which is a hash that contains "headers" and "original_url".