### PR TITLE
Fix permitted group_refs parameter for worflow creation

### DIFF
--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -41,7 +41,7 @@ module Api
       private
 
       def workflow_params
-        params.permit(:name, :description, :limit, :offset, :group_ids => [])
+        params.permit(:name, :description, :limit, :offset, :group_refs => [])
       end
     end
   end

--- a/spec/requests/v1.0/workflows_spec.rb
+++ b/spec/requests/v1.0/workflows_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe 'Workflows API' do
       end
     end
 
-    context 'when a request with invalid group_refs' do
-      before { post "#{api_version}/templates/#{template_id}/workflows", :params => { :group_refs => [-1, -2, -3] }, :headers => request_header }
+    context 'when a request with missing parameter' do
+      before { post "#{api_version}/templates/#{template_id}/workflows", :params => valid_attributes.slice(:description, :group_refs), :headers => request_header }
 
       it 'returns status code 422' do
         expect(response).to have_http_status(422)


### PR DESCRIPTION
Fixes https://projects.engineering.redhat.com/browse/SSP-266

It is a typo. Previously we were accepting `group_ids` now it got renamed to `group_refs`.