### PR TITLE
Seed built-in multi-level approval template to link to internal kieserver

### DIFF
--- a/app/models/encryption.rb
+++ b/app/models/encryption.rb
@@ -1,0 +1,21 @@
+require 'manageiq/password'
+class Encryption < ApplicationRecord
+  acts_as_tenant(:tenant, :has_global_records => true)
+
+  def secret
+    secret_encrypted.blank? ? secret_encrypted : ManageIQ::Password.decrypt(secret_encrypted)
+  end
+
+  def secret=(val)
+    val = ManageIQ::Password.try_encrypt(val) if val.present?
+    self.secret_encrypted = val
+  end
+
+  def secret_encrypted
+    self['secret']
+  end
+
+  def secret_encrypted=(val)
+    self['secret'] = val
+  end
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -50,9 +50,9 @@ class Template < ApplicationRecord
 
   def delete_passwords
     process_password_id = process_setting.try(:[], 'password')
-    Encryption.delete(process_password_id) if process_password_id
+    Encryption.destroy(process_password_id) if process_password_id
 
     signal_password_id = signal_setting.try(:[], 'password')
-    Encryption.delete(signal_password_id) if signal_password_id
+    Encryption.destroy(signal_password_id) if signal_password_id
   end
 end

--- a/app/services/jbpm_process_service.rb
+++ b/app/services/jbpm_process_service.rb
@@ -6,14 +6,14 @@ class JbpmProcessService
   end
 
   def start
-    options = template.process_setting
+    options = substitute_password(template.process_setting)
     Kie::Service.call(KieClient::ProcessInstancesBPMApi, options) do |bpm|
       bpm.start_process(options['container_id'], options['process_id'], :body => process_options)
     end
   end
 
   def signal(decision)
-    options = template.signal_setting
+    options = substitute_password(template.signal_setting)
     Kie::Service.call(KieClient::ProcessInstancesBPMApi, options) do |bpm|
       bpm.signal_process_instance(options['container_id'], request.process_ref, options['signal_name'], :body => signal_options(decision))
     end
@@ -33,5 +33,11 @@ class JbpmProcessService
   def signal_options(decision)
     # TODO: more options
     {'decision' => decision}
+  end
+
+  def substitute_password(options)
+    secret_id = options['password']
+    options['password'] = Encryption.find(secret_id).secret
+    options
   end
 end

--- a/db/migrate/20190403173445_create_encryptions.rb
+++ b/db/migrate/20190403173445_create_encryptions.rb
@@ -1,0 +1,10 @@
+class CreateEncryptions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :encryptions do |t|
+      t.bigint :tenant_id
+      t.string :secret
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_165411) do
+ActiveRecord::Schema.define(version: 2019_04_03_173445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,13 @@ ActiveRecord::Schema.define(version: 2019_04_02_165411) do
     t.bigint "tenant_id"
     t.index ["stage_id"], name: "index_actions_on_stage_id"
     t.index ["tenant_id"], name: "index_actions_on_tenant_id"
+  end
+
+  create_table "encryptions", force: :cascade do |t|
+    t.bigint "tenant_id"
+    t.string "secret"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "requests", force: :cascade do |t|
@@ -56,8 +63,8 @@ ActiveRecord::Schema.define(version: 2019_04_02_165411) do
     t.string "group_ref"
     t.string "random_access_key"
     t.index ["group_ref"], name: "index_stages_on_group_ref"
-    t.index ["request_id"], name: "index_stages_on_request_id"
     t.index ["random_access_key"], name: "index_stages_on_random_access_key"
+    t.index ["request_id"], name: "index_stages_on_request_id"
     t.index ["tenant_id"], name: "index_stages_on_tenant_id"
   end
 

--- a/spec/models/encryption_spec.rb
+++ b/spec/models/encryption_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Encryption, type: :model do
+RSpec.describe(Encryption, :type => :model) do
   it 'encrypts and decrypts a secret' do
     expect(ManageIQ::Password).to receive(:encrypt).and_return('xyz')
     expect(ManageIQ::Password).to receive(:decrypt).and_return('abc')

--- a/spec/models/encryption_spec.rb
+++ b/spec/models/encryption_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Encryption, type: :model do
+  it 'encrypts and decrypts a secret' do
+    expect(ManageIQ::Password).to receive(:encrypt).and_return('xyz')
+    expect(ManageIQ::Password).to receive(:decrypt).and_return('abc')
+
+    test = Encryption.create(:secret => 'test')
+    expect(test.secret).to eq('abc')
+    expect(test.secret_encrypted).to eq('xyz')
+  end
+end

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe Template, type: :model do
       ENV['KIE_CONTAINER_ID']    = 'approval_1.0.0'
       ENV['BPM_BML_PROCESS_ID']  = 'com.redhat.management.approval.MultiStageEmails'
       ENV['BPM_BML_SIGNAL_NAME'] = 'nextGroup'
-
-      #require 'manageiq/password'
-
-      #allow(ManageIQ::Password).to receive(:encrypt).and_return('xyz')
     end
 
     after do
@@ -29,8 +25,7 @@ RSpec.describe Template, type: :model do
       described_class.seed
       expect(described_class.count).to eq(1)
 
-      template = described_class.first
-      expect(template.title).to eq('Basic')
+      template = described_class.find_by(:title => 'Basic')
       expect(template.process_setting).to include(
         'host'         => 'localhost:8080',
         'username'     => 'executionUser',
@@ -46,12 +41,21 @@ RSpec.describe Template, type: :model do
         'signal_name'  => 'nextGroup',
       )
     end
+
+    it 'skips already seeded record' do
+      described_class.seed
+      template_first_round = described_class.find_by(:title => 'Basic')
+
+      described_class.seed
+      tempalte_second_round = described_class.find_by(:title => 'Basic')
+      expect(template_first_round.attributes).to eq(tempalte_second_round.attributes)
+    end
   end
 
   describe '#destroy' do
-    let (:password_id1) { Encryption.create!.id }
-    let (:password_id2) { Encryption.create!.id }
-    let (:template) { FactoryBot.create(:template, :process_setting => {'password' => password_id1}, :signal_setting => {'password' => password_id2})}
+    let(:password_id1) { Encryption.create!.id }
+    let(:password_id2) { Encryption.create!.id }
+    let(:template) { FactoryBot.create(:template, :process_setting => {'password' => password_id1}, :signal_setting => {'password' => password_id2}) }
 
     it 'deletes encrypted passwords' do
       expect(Encryption.where(:id => password_id1)).to exist

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -3,10 +3,62 @@ RSpec.describe Template, type: :model do
   it { should validate_presence_of(:title) }
 
   describe '.seed' do
+    before do
+      ENV['KIE_SERVER_HOST']     = 'localhost:8080'
+      ENV['KIE_SERVER_USERNAME'] = 'executionUser'
+      ENV['KIE_SERVER_PASSWORD'] = 'password'
+      ENV['KIE_CONTAINER_ID']    = 'approval_1.0.0'
+      ENV['BPM_BML_PROCESS_ID']  = 'com.redhat.management.approval.MultiStageEmails'
+      ENV['BPM_BML_SIGNAL_NAME'] = 'nextGroup'
+
+      #require 'manageiq/password'
+
+      #allow(ManageIQ::Password).to receive(:encrypt).and_return('xyz')
+    end
+
+    after do
+      ENV['KIE_SERVER_HOST']     = nil
+      ENV['KIE_SERVER_USERNAME'] = nil
+      ENV['KIE_SERVER_PASSWORD'] = nil
+      ENV['KIE_CONTAINER_ID']    = nil
+      ENV['BPM_BML_PROCESS_ID']  = nil
+      ENV['BPM_BML_SIGNAL_NAME'] = nil
+    end
+
     it 'creates a default template' do
       described_class.seed
       expect(described_class.count).to eq(1)
-      expect(described_class.first.title).to eq('Basic')
+
+      template = described_class.first
+      expect(template.title).to eq('Basic')
+      expect(template.process_setting).to include(
+        'host'         => 'localhost:8080',
+        'username'     => 'executionUser',
+        'password'     => a_kind_of(Integer),
+        'container_id' => 'approval_1.0.0',
+        'process_id'   => 'com.redhat.management.approval.MultiStageEmails'
+      )
+      expect(template.signal_setting).to include(
+        'host'         => 'localhost:8080',
+        'username'     => 'executionUser',
+        'password'     => a_kind_of(Integer),
+        'container_id' => 'approval_1.0.0',
+        'signal_name'  => 'nextGroup',
+      )
+    end
+  end
+
+  describe '#destroy' do
+    let (:password_id1) { Encryption.create!.id }
+    let (:password_id2) { Encryption.create!.id }
+    let (:template) { FactoryBot.create(:template, :process_setting => {'password' => password_id1}, :signal_setting => {'password' => password_id2})}
+
+    it 'deletes encrypted passwords' do
+      expect(Encryption.where(:id => password_id1)).to exist
+      expect(Encryption.where(:id => password_id2)).to exist
+      template.destroy
+      expect(Encryption.where(:id => password_id1)).not_to exist
+      expect(Encryption.where(:id => password_id2)).not_to exist
     end
   end
 end

--- a/spec/services/jbpm_process_service_spec.rb
+++ b/spec/services/jbpm_process_service_spec.rb
@@ -1,14 +1,22 @@
 RSpec.describe JbpmProcessService do
-  let(:common_setting) do
-    {'processor_type' => 'jbpm', 'host' => 'http://url', 'username' => 'u', 'password' => 'p', 'container_id' => 'can'}
-  end
-
   let(:template) do
-    create(
-      :template,
-      :process_setting => common_setting.merge('process_id' => 'proc'),
-      :signal_setting  => common_setting.merge('signal_name'  => 'sig'),
-    )
+    ENV['KIE_SERVER_HOST']     = 'localhost:8080'
+    ENV['KIE_SERVER_USERNAME'] = 'executionUser'
+    ENV['KIE_SERVER_PASSWORD'] = 'password'
+    ENV['KIE_CONTAINER_ID']    = 'can'
+    ENV['BPM_BML_PROCESS_ID']  = 'proc'
+    ENV['BPM_BML_SIGNAL_NAME'] = 'sig'
+
+    Template.seed
+
+    ENV['KIE_SERVER_HOST']     = nil
+    ENV['KIE_SERVER_USERNAME'] = nil
+    ENV['KIE_SERVER_PASSWORD'] = nil
+    ENV['KIE_CONTAINER_ID']    = nil
+    ENV['BPM_BML_PROCESS_ID']  = nil
+    ENV['BPM_BML_SIGNAL_NAME'] = nil
+
+    Template.find_by(:title => 'Basic')
   end
 
   let(:workflow) { create(:workflow, :template => template) }


### PR DESCRIPTION
1. Create the encryptions table to store encrypted secrets.
2. Config `process_setting` and `signal_setting` of the build-in multi-level approval template to communicate with the internal kieserver through ENV variables.
3. Encrypt passwords