### PR TITLE
Use the routing helper from api common to handle major version redirects

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,16 @@ Rails.application.routes.draw do
   def put(*_args)
   end
 
+  routing_helper = ManageIQ::API::Common::Routing.new(self)
+
   prefix = "api"
   if ENV["PATH_PREFIX"].present? && ENV["APP_NAME"].present?
     prefix = File.join(ENV["PATH_PREFIX"], ENV["APP_NAME"]).gsub(/^\/+|\/+$/, "")
   end
 
   scope :as => :api, :module => "api", :path => prefix do
-    match "/v1/*path", :via => %i(delete get patch post), :to => redirect(:path => "/#{prefix}/v1.0/%{path}", :only_path => true)
+    routing_helper.redirect_major_version("v1.0", prefix)
+
     namespace :v1x0, :path => "v1.0" do
       get "/openapi.json", :to => "root#openapi"
       resources :actions, :only => [:show]

--- a/spec/requests/v1.0/root_spec.rb
+++ b/spec/requests/v1.0/root_spec.rb
@@ -10,5 +10,12 @@ RSpec.describe "root", :type => :request do
       expect(response.content_type).to eq("application/json")
       expect(response).to have_http_status(:ok)
     end
+
+    it "redirects properly" do
+      get "#{api_version.split('.').first}/openapi.json", :headers => request_header
+
+      expect(response.status).to eq(302)
+      expect(response.headers["Location"]).to eq("#{api_version}/openapi.json")
+    end
   end
 end


### PR DESCRIPTION
This changes the redirect code from 301 to 302 and fixes an issue
where /openapi.json would redirect to /openapi

Requires https://github.com/ManageIQ/manageiq-api-common/pull/50

@miq-bot assign @Fryguy 