### PR TITLE
Change when context is stored on Request

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -18,7 +18,7 @@ class Request < ApplicationRecord
   scope :state,     ->(state)     { where(:state => state) }
   scope :requester, ->(requester) { where(:requester => requester) }
 
-  after_initialize :set_context
+  before_create :set_context
 
   private
 

--- a/spec/requests/v1.0/requests_spec.rb
+++ b/spec/requests/v1.0/requests_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe 'Requests API' do
   let!(:template) { create(:template) }
   let!(:workflow) { create(:workflow, :name => 'Always approve') } #:template_id => template.id) }
   let(:workflow_id) { workflow.id }
-  let!(:requests) { create_list(:request, 2, :workflow_id => workflow.id, :tenant_id => tenant.id) }
+  let!(:requests) do
+    ManageIQ::API::Common::Request.with_request(:headers => request_header, :original_url => "localhost/approval") do
+      create_list(:request, 2, :workflow_id => workflow.id, :tenant_id => tenant.id)
+    end
+  end
   let(:id) { requests.first.id }
   let!(:requests_with_same_state) { create_list(:request, 2, :state => 'notified', :workflow_id => workflow.id, :tenant_id => tenant.id) }
   let!(:requests_with_same_decision) { create_list(:request, 2, :decision => 'approved', :workflow_id => workflow.id, :tenant_id => tenant.id) }


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-270

Change the way context is stored, so that it only gets set once (when the `Request` is created).
I'll work on changing the MIQ-api-common gem to work with either type of keys as well, that way we don't have to transform the keys in order to use it. 