### PR TITLE
Use ENV set by OCP for kie server host and port

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -17,12 +17,12 @@ class Template < ApplicationRecord
   end
 
   private_class_method def self.seed_process_setting(old_setting)
-    return nil unless ENV['KIE_SERVER_HOST']
+    return nil unless ENV['APPROVAL_PAM_SERVICE_HOST']
     seed_bpm_setting(old_setting).merge('process_id' => ENV['BPM_BML_PROCESS_ID'])
   end
 
   private_class_method def self.seed_signal_setting(old_setting)
-    return nil unless ENV['KIE_SERVER_HOST']
+    return nil unless ENV['APPROVAL_PAM_SERVICE_HOST']
     seed_bpm_setting(old_setting).merge('signal_name' => ENV['BPM_BML_SIGNAL_NAME'])
   end
 
@@ -42,7 +42,7 @@ class Template < ApplicationRecord
       'container_id' => ENV['KIE_CONTAINER_ID'],
       'password'     => new_password_id,
       'username'     => ENV['KIE_SERVER_USERNAME'],
-      'host'         => ENV['KIE_SERVER_HOST']
+      'host'         => "#{ENV['APPROVAL_PAM_SERVICE_HOST']}:#{ENV['APPROVAL_PAM_SERVICE_PORT']}"
     }
   end
 

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -4,21 +4,23 @@ RSpec.describe Template, type: :model do
 
   describe '.seed' do
     before do
-      ENV['KIE_SERVER_HOST']     = 'localhost:8080'
-      ENV['KIE_SERVER_USERNAME'] = 'executionUser'
-      ENV['KIE_SERVER_PASSWORD'] = 'password'
-      ENV['KIE_CONTAINER_ID']    = 'approval_1.0.0'
-      ENV['BPM_BML_PROCESS_ID']  = 'com.redhat.management.approval.MultiStageEmails'
-      ENV['BPM_BML_SIGNAL_NAME'] = 'nextGroup'
+      ENV['APPROVAL_PAM_SERVICE_HOST'] = 'localhost'
+      ENV['APPROVAL_PAM_SERVICE_PORT'] = '8080'
+      ENV['KIE_SERVER_USERNAME']       = 'executionUser'
+      ENV['KIE_SERVER_PASSWORD']       = 'password'
+      ENV['KIE_CONTAINER_ID']          = 'approval_1.0.0'
+      ENV['BPM_BML_PROCESS_ID']        = 'com.redhat.management.approval.MultiStageEmails'
+      ENV['BPM_BML_SIGNAL_NAME']       = 'nextGroup'
     end
 
     after do
-      ENV['KIE_SERVER_HOST']     = nil
-      ENV['KIE_SERVER_USERNAME'] = nil
-      ENV['KIE_SERVER_PASSWORD'] = nil
-      ENV['KIE_CONTAINER_ID']    = nil
-      ENV['BPM_BML_PROCESS_ID']  = nil
-      ENV['BPM_BML_SIGNAL_NAME'] = nil
+      ENV['APPROVAL_PAM_SERVICE_HOST'] = nil
+      ENV['APPROVAL_PAM_SERVICE_PORT'] = nil
+      ENV['KIE_SERVER_USERNAME']       = nil
+      ENV['KIE_SERVER_PASSWORD']       = nil
+      ENV['KIE_CONTAINER_ID']          = nil
+      ENV['BPM_BML_PROCESS_ID']        = nil
+      ENV['BPM_BML_SIGNAL_NAME']       = nil
     end
 
     it 'creates a default template' do

--- a/spec/services/jbpm_process_service_spec.rb
+++ b/spec/services/jbpm_process_service_spec.rb
@@ -1,20 +1,22 @@
 RSpec.describe JbpmProcessService do
   let(:template) do
-    ENV['KIE_SERVER_HOST']     = 'localhost:8080'
-    ENV['KIE_SERVER_USERNAME'] = 'executionUser'
-    ENV['KIE_SERVER_PASSWORD'] = 'password'
-    ENV['KIE_CONTAINER_ID']    = 'can'
-    ENV['BPM_BML_PROCESS_ID']  = 'proc'
-    ENV['BPM_BML_SIGNAL_NAME'] = 'sig'
+    ENV['APPROVAL_PAM_SERVICE_HOST'] = 'localhost'
+    ENV['APPROVAL_PAM_SERVICE_PORT'] = '8080'
+    ENV['KIE_SERVER_USERNAME']       = 'executionUser'
+    ENV['KIE_SERVER_PASSWORD']       = 'password'
+    ENV['KIE_CONTAINER_ID']          = 'can'
+    ENV['BPM_BML_PROCESS_ID']        = 'proc'
+    ENV['BPM_BML_SIGNAL_NAME']       = 'sig'
 
     Template.seed
 
-    ENV['KIE_SERVER_HOST']     = nil
-    ENV['KIE_SERVER_USERNAME'] = nil
-    ENV['KIE_SERVER_PASSWORD'] = nil
-    ENV['KIE_CONTAINER_ID']    = nil
-    ENV['BPM_BML_PROCESS_ID']  = nil
-    ENV['BPM_BML_SIGNAL_NAME'] = nil
+    ENV['APPROVAL_PAM_SERVICE_HOST'] = nil
+    ENV['APPROVAL_PAM_SERVICE_PORT'] = nil
+    ENV['KIE_SERVER_USERNAME']       = nil
+    ENV['KIE_SERVER_PASSWORD']       = nil
+    ENV['KIE_CONTAINER_ID']          = nil
+    ENV['BPM_BML_PROCESS_ID']        = nil
+    ENV['BPM_BML_SIGNAL_NAME']       = nil
 
     Template.find_by(:title => 'Basic')
   end


### PR DESCRIPTION
Previously we relied on ENV `KIE_SERVER_HOST` to pass in the kie server host. Now we learned OCP already provided `APPROVAL_PAM_SERVICE_HOST` that we can use. This PR follows the same pattern from https://github.com/ManageIQ/topological_inventory-openshift/blob/master/bin/openshift-operations#L12