### PR TITLE
Restore request context in a separate thread

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -21,11 +21,7 @@ class Request < ApplicationRecord
   before_create :set_context
 
   def switch_context
-    if context.present?
-      ManageIQ::API::Common::Request.with_request(context.transform_keys(&:to_sym)) do
-        ActsAsTenant.with_tenant(tenant) { yield }
-      end
-    else
+    ManageIQ::API::Common::Request.with_request(context.transform_keys(&:to_sym)) do
       ActsAsTenant.with_tenant(tenant) { yield }
     end
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -20,6 +20,16 @@ class Request < ApplicationRecord
 
   before_create :set_context
 
+  def switch_context
+    if context.present?
+      ManageIQ::API::Common::Request.with_request(context.transform_keys(&:to_sym)) do
+        ActsAsTenant.with_tenant(tenant) { yield }
+      end
+    else
+      ActsAsTenant.with_tenant(tenant) { yield }
+    end
+  end
+
   private
 
   def set_context

--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -46,7 +46,9 @@ class RequestCreateService
 
   def start_internal_approval_process(request)
     Thread.new do
-      default_approve? ? default_approve(request) : auto_approve(request)
+      request.switch_context do
+        default_approve? ? default_approve(request) : auto_approve(request)
+      end
     end
   end
 

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -13,12 +13,7 @@ FactoryBot.define do
 
     trait :with_context do
       after(:create) do |obj|
-        obj.update_attributes(:context =>
-          {
-            "headers"      => {"x-rh-identity" => RequestSpecHelper.encoded_user_hash},
-            "original_url" => "http://localhost:3000/api/v1.0/workflows/1/requests"
-          }
-        )
+        obj.update_attributes(:context => RequestSpecHelper.default_request_hash)
       end
     end
 

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -10,5 +10,20 @@ FactoryBot.define do
     decision     { :undecided }
 
     workflow
+
+    trait :with_context do
+      after(:create) do |obj|
+        obj.update_attributes(:context =>
+          {
+            "headers"      => {"x-rh-identity" => RequestSpecHelper.encoded_user_hash},
+            "original_url" => "http://localhost:3000/api/v1.0/workflows/1/requests"
+          }
+        )
+      end
+    end
+
+    trait :with_tenant do
+      tenant
+    end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -4,4 +4,25 @@ RSpec.describe Request, type: :model do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:content) }
+
+  describe '#switch_context' do
+    context 'with context' do
+      it 'sets the http request header and current tenant' do
+        request = FactoryBot.create(:request, :with_context)
+        request.switch_context do
+          expect(ManageIQ::API::Common::Request.current.to_h).to eq(request.context.transform_keys(&:to_sym))
+          expect(ActsAsTenant.current_tenant).to eq(request.tenant)
+        end
+      end
+    end
+
+    context 'without context' do
+      it 'sets current tenant' do
+        request = FactoryBot.create(:request, :with_tenant)
+        request.switch_context do
+          expect(ActsAsTenant.current_tenant).to eq(request.tenant)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Request, type: :model do
     context 'without context' do
       it 'raises an error' do
         request = FactoryBot.create(:request, :with_tenant)
-        expect { request.switch_context}.to raise_error(ArgumentError)
+        expect { request.switch_context }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -17,11 +17,9 @@ RSpec.describe Request, type: :model do
     end
 
     context 'without context' do
-      it 'sets current tenant' do
+      it 'raises an error' do
         request = FactoryBot.create(:request, :with_tenant)
-        request.switch_context do
-          expect(ActsAsTenant.current_tenant).to eq(request.tenant)
-        end
+        expect { request.switch_context}.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe RequestCreateService do
     end
 
     it 'creates a request and auto approves' do
+      expect_any_instance_of(Request).to receive(:switch_context).and_yield
       request = subject.create(:name => 'req1', :requester => 'test', :content => 'test me')
       request.reload
       expect(request).to have_attributes(
@@ -101,6 +102,7 @@ RSpec.describe RequestCreateService do
     before { allow(Thread).to receive(:new).and_yield }
 
     it 'creates a request and auto approves' do
+      expect_any_instance_of(Request).to receive(:switch_context).and_yield
       request = subject.create(:name => 'req2', :requester => 'test2', :content => 'test me')
       request.reload
       expect(request).to have_attributes(

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,6 +1,6 @@
 # spec/support/request_spec_helper
 module RequestSpecHelper
-  extend self
+  module_function
 
   # Parse JSON response to ruby hash
   def json

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -49,4 +49,12 @@ module RequestSpecHelper
   def default_user_hash
     Marshal.load(Marshal.dump(DEFAULT_USER))
   end
+
+  def default_headers
+    {'x-rh-identity' => encoded_user_hash, 'x-rh-insights-request-id' => 'gobbledygook'}
+  end
+
+  def default_request_hash
+    {:headers => default_headers, :original_url => 'https://xyz.com/api/requests'}
+  end
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,5 +1,7 @@
 # spec/support/request_spec_helper
 module RequestSpecHelper
+  extend self
+
   # Parse JSON response to ruby hash
   def json
     JSON.parse(response.body)


### PR DESCRIPTION
When creating a new request in another thread we need to pass the current header/tenant to the thread. This is done through reconstructing from the context attribute in the request model.

Fixes https://github.com/ManageIQ/approval-api/issues/83