### PR TITLE
Remove context column from all responses via OpenApi::Serializer

### DIFF
--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,5 +1,5 @@
 module Response
   def json_response(object, status = :ok)
-    render json: object, status: status
+    render :json => object.as_json(:except => :context), :status => status
   end
 end

--- a/spec/requests/v1.0/requests_spec.rb
+++ b/spec/requests/v1.0/requests_spec.rb
@@ -62,8 +62,12 @@ RSpec.describe 'Requests API' do
     end
 
     it 'sets the context' do
-      expect(json['data'].first['context'].keys).to eq %w[headers original_url]
-      expect(json['data'].first['context']['headers']['x-rh-identity']).to eq encoded_user
+      expect(requests.first.context.keys).to eq %w[headers original_url]
+      expect(requests.first.context['headers']['x-rh-identity']).to eq encoded_user
+    end
+
+    it 'does not include context in the response' do
+      expect(json.key?("context")).to be_falsey
     end
 
     it 'can recreate the request from context' do


### PR DESCRIPTION
Modify the `OpenApi::Serializer` class to remove `context` from the responses anywhere it is set. This is primarily in the `Request` class for now, but can be expanded in the future if needed