### PR TITLE
Hardcode seeding BPM parameters

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -18,12 +18,12 @@ class Template < ApplicationRecord
 
   private_class_method def self.seed_process_setting(old_setting)
     return nil unless ENV['APPROVAL_PAM_SERVICE_HOST']
-    seed_bpm_setting(old_setting).merge('process_id' => ENV['BPM_BML_PROCESS_ID'])
+    seed_bpm_setting(old_setting).merge('process_id' => 'MultiStageEmails')
   end
 
   private_class_method def self.seed_signal_setting(old_setting)
     return nil unless ENV['APPROVAL_PAM_SERVICE_HOST']
-    seed_bpm_setting(old_setting).merge('signal_name' => ENV['BPM_BML_SIGNAL_NAME'])
+    seed_bpm_setting(old_setting).merge('signal_name' => 'nextGroup')
   end
 
   private_class_method def self.seed_bpm_setting(old_setting)
@@ -39,7 +39,7 @@ class Template < ApplicationRecord
       end
 
     {
-      'container_id' => ENV['KIE_CONTAINER_ID'],
+      'container_id' => 'approval',
       'password'     => new_password_id,
       'username'     => ENV['KIE_SERVER_USERNAME'],
       'host'         => "#{ENV['APPROVAL_PAM_SERVICE_HOST']}:#{ENV['APPROVAL_PAM_SERVICE_PORT']}"

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -8,9 +8,6 @@ RSpec.describe Template, type: :model do
       ENV['APPROVAL_PAM_SERVICE_PORT'] = '8080'
       ENV['KIE_SERVER_USERNAME']       = 'executionUser'
       ENV['KIE_SERVER_PASSWORD']       = 'password'
-      ENV['KIE_CONTAINER_ID']          = 'approval_1.0.0'
-      ENV['BPM_BML_PROCESS_ID']        = 'com.redhat.management.approval.MultiStageEmails'
-      ENV['BPM_BML_SIGNAL_NAME']       = 'nextGroup'
     end
 
     after do
@@ -18,9 +15,6 @@ RSpec.describe Template, type: :model do
       ENV['APPROVAL_PAM_SERVICE_PORT'] = nil
       ENV['KIE_SERVER_USERNAME']       = nil
       ENV['KIE_SERVER_PASSWORD']       = nil
-      ENV['KIE_CONTAINER_ID']          = nil
-      ENV['BPM_BML_PROCESS_ID']        = nil
-      ENV['BPM_BML_SIGNAL_NAME']       = nil
     end
 
     it 'creates a default template' do
@@ -32,14 +26,14 @@ RSpec.describe Template, type: :model do
         'host'         => 'localhost:8080',
         'username'     => 'executionUser',
         'password'     => a_kind_of(Integer),
-        'container_id' => 'approval_1.0.0',
-        'process_id'   => 'com.redhat.management.approval.MultiStageEmails'
+        'container_id' => 'approval',
+        'process_id'   => 'MultiStageEmails'
       )
       expect(template.signal_setting).to include(
         'host'         => 'localhost:8080',
         'username'     => 'executionUser',
         'password'     => a_kind_of(Integer),
-        'container_id' => 'approval_1.0.0',
+        'container_id' => 'approval',
         'signal_name'  => 'nextGroup',
       )
     end

--- a/spec/services/jbpm_process_service_spec.rb
+++ b/spec/services/jbpm_process_service_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe JbpmProcessService do
     ENV['APPROVAL_PAM_SERVICE_PORT'] = '8080'
     ENV['KIE_SERVER_USERNAME']       = 'executionUser'
     ENV['KIE_SERVER_PASSWORD']       = 'password'
-    ENV['KIE_CONTAINER_ID']          = 'can'
-    ENV['BPM_BML_PROCESS_ID']        = 'proc'
-    ENV['BPM_BML_SIGNAL_NAME']       = 'sig'
 
     Template.seed
 
@@ -14,9 +11,6 @@ RSpec.describe JbpmProcessService do
     ENV['APPROVAL_PAM_SERVICE_PORT'] = nil
     ENV['KIE_SERVER_USERNAME']       = nil
     ENV['KIE_SERVER_PASSWORD']       = nil
-    ENV['KIE_CONTAINER_ID']          = nil
-    ENV['BPM_BML_PROCESS_ID']        = nil
-    ENV['BPM_BML_SIGNAL_NAME']       = nil
 
     Template.find_by(:title => 'Basic')
   end
@@ -32,13 +26,13 @@ RSpec.describe JbpmProcessService do
   end
 
   it 'starts a business process' do
-    expect(jbpm).to receive(:start_process).with('can', 'proc', hash_including(:body))
+    expect(jbpm).to receive(:start_process).with('approval', 'MultiStageEmails', hash_including(:body))
     subject.start
   end
 
   it 'sends a signal to a business process' do
     request.update_attributes(:process_ref => '100')
-    expect(jbpm).to receive(:signal_process_instance).with('can', '100', 'sig', hash_including(:body))
+    expect(jbpm).to receive(:signal_process_instance).with('approval', '100', 'nextGroup', hash_including(:body))
     subject.signal('approved')
   end
 end


### PR DESCRIPTION
In #84 the BPM parameters are passed in through ENV. From the review comments of the PR to create such ENVs in the OCP deployment it is recommended to have these parameters hardcoded in the app. It makes sense because these parameters are for seeding and should not change.