### PR TITLE
prepare v2_key at startup

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -1,4 +1,14 @@
 #!/bin/bash
+function write_encryption_key() {
+  echo "== Writing encryption key =="
+  cat > $WORKDIR/v2_key << KEY
+---
+:algorithm: aes-256-cbc
+:key: ${ENCRYPTION_KEY}
+KEY
+}
+
+write_encryption_key
 
 bundle exec rake db:migrate db:seed
 bundle exec rails server


### PR DESCRIPTION
Following logic from https://github.com/ManageIQ/topological_inventory-api/blob/master/docker-assets/run_rails_server