### PR TITLE
Enhance request api to include active stage and timestamps

### DIFF
--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -14,13 +14,9 @@ module Api
       end
 
       def index
-        if params[:workflow_id]
-          workflow = Workflow.find(params.require(:workflow_id))
-          collection(workflow.requests)
-        else
-          reqs = Request.filter(params.slice(:requester, :decision, :state))
-          collection(reqs)
-        end
+        Workflow.find(params.require(:workflow_id)) if params[:workflow_id] # to validate the workflow exists
+        reqs = Request.includes(:stages).filter(params.slice(:requester, :decision, :state, :workflow_id))
+        collection(reqs)
       end
 
       private

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -5,7 +5,7 @@ module Filterable
     def filter(filtering_params)
       results = self.where(nil)
       filtering_params.each do |key, value|
-        results = results.public_send(key, value) if value.present?
+        results = results.where(key => value) if value.present?
       end
       results
     end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -26,7 +26,28 @@ class Request < ApplicationRecord
     end
   end
 
+  def as_json(options = {})
+    super(options.merge(:methods => [:total_stages, :active_stage]))
+  end
+
   private
+
+  def total_stages
+    stages.size
+  end
+
+  def active_stage
+    return 0 if total_stages.zero?
+
+    # return 1-based active stage
+    active_stage = stages.find_index { |st| st.state == Stage::NOTIFIED_STATE || st.state == Stage::PENDING_STATE }
+    if active_stage.nil?
+      # no stage in active, must have completed
+      stages.size
+    else
+      active_stage + 1
+    end
+  end
 
   def set_context
     self.context = ManageIQ::API::Common::Request.current.to_h

--- a/public/approval/v1.0/openapi.json
+++ b/public/approval/v1.0/openapi.json
@@ -1139,6 +1139,24 @@
                                 "type": "string",
                                 "description": "Associate workflow id"
                             }
+                            "created_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Timestamp of creation"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Timestamp of last update"
+                            },
+                            "active_stage": {
+                                "type": "integer",
+                                "description": "Current (or last) active stage. For regular approver this number is always 0"
+                            },
+                            "total_stages": {
+                                "type": "integer",
+                                "description": "Total number of stages. For regular approver this number is always 0."
+                            }
                         }
                     }
                 ]

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -23,4 +23,44 @@ RSpec.describe Request, type: :model do
       end
     end
   end
+
+  describe '#as_json' do
+    subject { FactoryBot.create(:request, :stages => stages) }
+
+    context 'all stages are pending or notified' do
+      let(:stages) do
+        [FactoryBot.create(:stage, :state => Stage::NOTIFIED_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE)]
+      end
+
+      it 'has active_stage pointing to the first stage' do
+        expect(subject.as_json).to include('active_stage' => 1, 'total_stages' => 3)
+      end
+    end
+
+    context 'all stages are completed' do
+      let(:stages) do
+        [FactoryBot.create(:stage, :state => Stage::FINISHED_STATE),
+         FactoryBot.create(:stage, :state => Stage::SKIPPED_STATE),
+         FactoryBot.create(:stage, :state => Stage::SKIPPED_STATE)]
+      end
+
+      it 'has active_stage pointing to the first stage' do
+        expect(subject.as_json).to include('active_stage' => 3, 'total_stages' => 3)
+      end
+    end
+
+    context 'some stage is active' do
+      let(:stages) do
+        [FactoryBot.create(:stage, :state => Stage::FINISHED_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE)]
+      end
+
+      it 'has active_stage pointing to the first stage' do
+        expect(subject.as_json).to include('active_stage' => 2, 'total_stages' => 3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This work is to enhance the request API to include attributes `created_at`, `updated_at`, `active_stage` and `total_stages`. The last two attributes are virtual. 

The list query of requests also preloads stages that helps to reduce the number of sql queries.