### PR TITLE
Fixed missing comma in json schema.

### DIFF
--- a/public/approval/v1.0/openapi.json
+++ b/public/approval/v1.0/openapi.json
@@ -1138,7 +1138,7 @@
                             "workflow_id": {
                                 "type": "string",
                                 "description": "Associate workflow id"
-                            }
+                            },
                             "created_at": {
                                 "type": "string",
                                 "format": "date-time",


### PR DESCRIPTION
Missing coma in json schema. Need it to generate new JS client.

cc @lgalis 

I think this there is a validator for the openApi schema. Might be nice to turn it on in CI. 

Edit: Some of them are listed here: https://openapi.tools/.