### PR TITLE
Improved status message in webpage approval

### DIFF
--- a/app/controllers/api/v1x0/stageaction/result.html.erb
+++ b/app/controllers/api/v1x0/stageaction/result.html.erb
@@ -16,10 +16,10 @@
         <font face="verdana"><br>
           <font size="22" color="red"><b><%= @resources[:approval_web_product] %></font><hr>
             <% if response.status != 200 %>
-            <h1 font size="24">Your request failed to complete: </h1>
+              <h1 font size="24">Unable to complete your approval action [<%= params[:commit] %>]</h1>
             <p><strong>Reason:</strong><%= response.body %></p>
             <% else %>
-            <h1 font size="24">Your action has been executed successfully</h1>
+              <h1 font size="24">Your approval action [<%= params[:commit] %>] is completed</h1>
             <% end %>
             
             <% if @order %>

--- a/app/controllers/api/v1x0/stageaction/result.html.erb
+++ b/app/controllers/api/v1x0/stageaction/result.html.erb
@@ -16,10 +16,10 @@
         <font face="verdana"><br>
           <font size="22" color="red"><b><%= @resources[:approval_web_product] %></font><hr>
             <% if response.status != 200 %>
-              <h1 font size="24">Unable to complete your approval action [<%= params[:commit] %>]</h1>
+              <h1 font size="24">Unable to complete action [<%= params[:commit] %>]</h1>
             <p><strong>Reason:</strong><%= response.body %></p>
             <% else %>
-              <h1 font size="24">Your approval action [<%= params[:commit] %>] is completed</h1>
+              <h1 font size="24">Your action [<%= params[:commit] %>] has been recorded.</h1>
             <% end %>
             
             <% if @order %>

--- a/app/controllers/api/v1x0/stageaction/show.html.erb
+++ b/app/controllers/api/v1x0/stageaction/show.html.erb
@@ -30,7 +30,7 @@
       <%= image_tag(@resources[:approval_web_logo], :size => '300x150') %>
         <font face="verdana"><br>
           <font size="22" color="red"><b><%= @resources[:approval_web_product] %></font><hr>
-            <h1><font size="24">Catalog Request </font><a href="#" onclick="showDetails()">(Detail)</a></h1>
+            <h1><font size="24">Catalog Request </font><a href="#" onclick="showDetails()">(Details)</a></h1>
             <p>
             <table>
               <tr><td><b><font size="14">Ordered By</b></td><td><font size="14"> :<%= @order[:orderer] %></td></tr>

--- a/app/controllers/api/v1x0/stageaction/show.html.erb
+++ b/app/controllers/api/v1x0/stageaction/show.html.erb
@@ -4,8 +4,8 @@
         textarea {
             width: 90%;
             height: 150;
-            margin: 20; /* don't want to add to container size */
-            border: 1; /* don't want to add to container size */
+            margin: 20;
+            border: 1;
             font-size: 22px;
         }
         input[type=submit] {

--- a/app/controllers/api/v1x0/stageaction_controller.rb
+++ b/app/controllers/api/v1x0/stageaction_controller.rb
@@ -12,7 +12,7 @@ module Api
       end
 
       rescue_from ActionController::ParameterMissing do |_e|
-        response.body = "The Reason/Memo is a required field for Deny/Memo actions"
+        response.body = "The Reason/Memo field is required for [Deny/Memo] actions"
         render :status => :unprocessable_entity, :action => :result
       end
 

--- a/app/controllers/api/v1x0/stageaction_controller.rb
+++ b/app/controllers/api/v1x0/stageaction_controller.rb
@@ -11,8 +11,8 @@ module Api
         render :status => :internal_server_error, :action => :result
       end
 
-      rescue_from ActionController::ParameterMissing do |e|
-        response.body = e.message
+      rescue_from ActionController::ParameterMissing do |_e|
+        response.body = "The Reason/Memo is a required field for Deny/Memo actions"
         render :status => :unprocessable_entity, :action => :result
       end
 


### PR DESCRIPTION
Changed to show approver's action inside the status message when approval via open link in the email.

Status message for succeeded action:
![image](https://user-images.githubusercontent.com/12900250/56380544-6f563500-61e0-11e9-9cf1-1259ad51abc9.png)

Status message for failed action:
![image](https://user-images.githubusercontent.com/12900250/56380439-27cfa900-61e0-11e9-9f0c-b2962a2cd962.png)
