### PR TITLE
Prevent default workflow from being destroyed

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -7,6 +7,8 @@ class Workflow < ApplicationRecord
   validates :name, :presence => true
   validate :unique_with_same_or_no_tenant
 
+  before_destroy :not_to_delete_default
+
   def self.seed
     workflow = find_or_create_by!(default_workflow_query)
     workflow.update_attributes!(
@@ -35,5 +37,11 @@ class Workflow < ApplicationRecord
 
   def external_signal?
     template.signal_setting.present?
+  end
+
+  private
+
+  def not_to_delete_default
+    throw :abort if {:name => name, :template => template} == self.class.send(:default_workflow_query)
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -7,7 +7,7 @@ class Workflow < ApplicationRecord
   validates :name, :presence => true
   validate :unique_with_same_or_no_tenant
 
-  before_destroy :not_to_delete_default
+  before_destroy :protect_default
 
   def self.seed
     workflow = find_or_create_by!(default_workflow_query)
@@ -41,7 +41,7 @@ class Workflow < ApplicationRecord
 
   private
 
-  def not_to_delete_default
+  def protect_default
     throw :abort if self.class.send(:default_workflow_query) == {:name => name, :template => template}
   end
 end

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -42,6 +42,6 @@ class Workflow < ApplicationRecord
   private
 
   def not_to_delete_default
-    throw :abort if {:name => name, :template => template} == self.class.send(:default_workflow_query)
+    throw :abort if self.class.send(:default_workflow_query) == {:name => name, :template => template}
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe Workflow, :type => :model do
       expect(described_class.count).to be(1)
       expect(described_class.first.template).to be_nil
     end
+
+    it 'cannot be destroyed' do
+      described_class.seed
+      expect { described_class.default_workflow.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    end
   end
 
   context "with same name in different tenants" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Workflow, :type => :model do
   it { should validate_presence_of(:name) }
 
   describe '.seed' do
+    after { Workflow.instance_variable_set(:@default_workflow, nil) }
+
     it 'creates a default workflow' do
       described_class.seed
       expect(described_class.count).to be(1)

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe RequestCreateService do
     let(:context_service) { double(:conext_service) }
 
     before { allow(Thread).to receive(:new).and_yield }
+    after  { Workflow.instance_variable_set(:@default_workflow, nil) }
 
     it 'creates a request and auto approves' do
       expect(ContextService).to receive(:new).and_return(context_service)


### PR DESCRIPTION
The default workflow that was created from seeding cannot be deleted.