### PR TITLE
Add index filtering via MIQ Common Gem

### DIFF
--- a/app/controllers/api/v1x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v1x0/mixins/index_mixin.rb
@@ -13,13 +13,36 @@ module Api
 
         def collection(base_query)
           resp = ManageIQ::API::Common::PaginatedResponse.new(
-            :base_query => scoped(base_query),
+            :base_query => filtered(scoped(base_query)),
             :request    => request,
             :limit      => params.permit(:limit)[:limit],
             :offset     => params.permit(:offset)[:offset]
           ).response
 
           json_response(resp)
+        end
+
+        def filtered(base_query)
+          ManageIQ::API::Common::Filter.new(base_query, params[:filter], api_doc_definition).apply
+        end
+
+        private
+
+        def api_doc_definition
+          @api_doc_definition ||= Api::Docs[api_version].definitions[model_name]
+        end
+
+        def api_version
+          @api_version ||= name.split("::")[1].downcase.delete("v").sub("x", ".")
+        end
+
+        def model_name
+          # Because approval uses the In/Out objects - we need to handle that appropriately.
+          @model_name ||= (controller_name.singularize + "Out").classify
+        end
+
+        def name
+          self.class.to_s
         end
       end
     end

--- a/lib/api/docs.rb
+++ b/lib/api/docs.rb
@@ -1,0 +1,3 @@
+module Api
+  Docs = ManageIQ::API::Common::OpenApi::Docs.new(Dir.glob(Rails.root.join("public", "**", "openapi*.json")))
+end

--- a/public/approval/v1.0/openapi.json
+++ b/public/approval/v1.0/openapi.json
@@ -201,6 +201,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -257,6 +260,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -487,6 +493,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -582,6 +591,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -638,6 +650,9 @@
                     },
                     {
                         "$ref": "#/components/parameters/offset"
+                    },
+                    {
+                        "$ref": "#/components/parameters/filter"
                     }
                 ],
                 "responses": {
@@ -941,6 +956,17 @@
                     "default": 0
                 }
             },
+            "filter": {
+                "in": "query",
+                "name": "filter",
+                "description": "Filter for querying collections.",
+                "required": false,
+                "style": "deepObject",
+                "explode": true,
+                "schema": {
+                    "type": "object"
+                }
+            },
             "state": {
                 "name": "state",
                 "in": "query",
@@ -1050,27 +1076,27 @@
                         "$ref": "#/components/schemas/ActionIn"
                     },
                     {
-                        "type": "object",
-                        "required": [
-                            "id",
-                            "stage_id"
-                        ],
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "created_at": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Timestamp of creation"
-                            },
-                            "stage_id": {
-                                "type": "string",
-                                "description": "Associated stage id"
-                            }
-                        }
+                        "type": "object"
                     }
-                ]
+                ],
+                "required": [
+                    "id",
+                    "stage_id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "stage_id": {
+                        "type": "string",
+                        "description": "Associated stage id"
+                    }
+                }
             },
             "RequestIn": {
                 "type": "object",
@@ -1105,61 +1131,61 @@
                         "$ref": "#/components/schemas/RequestIn"
                     },
                     {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "state": {
-                                "type": "string",
-                                "description": "The state of stage or request. It may be one of values (pending, skipped, notified or finished)",
-                                "enum": [
-                                    "pending",
-                                    "skipped",
-                                    "notified",
-                                    "finished"
-                                ],
-                                "default": "pending"
-                            },
-                            "decision": {
-                                "type": "string",
-                                "description": "Final decision, may be one of the value (undecided, approved, or denied)",
-                                "enum": [
-                                    "undecided",
-                                    "approved",
-                                    "denied"
-                                ],
-                                "default": "undecided"
-                            },
-                            "reason": {
-                                "type": "string",
-                                "description": "Comments for requests"
-                            },
-                            "workflow_id": {
-                                "type": "string",
-                                "description": "Associate workflow id"
-                            },
-                            "created_at": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Timestamp of creation"
-                            },
-                            "updated_at": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Timestamp of last update"
-                            },
-                            "active_stage": {
-                                "type": "integer",
-                                "description": "Current (or last) active stage. For regular approver this number is always 0"
-                            },
-                            "total_stages": {
-                                "type": "integer",
-                                "description": "Total number of stages. For regular approver this number is always 0."
-                            }
-                        }
+                        "type": "object"
                     }
-                ]
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string",
+                        "description": "The state of stage or request. It may be one of values (pending, skipped, notified or finished)",
+                        "enum": [
+                            "pending",
+                            "skipped",
+                            "notified",
+                            "finished"
+                        ],
+                        "default": "pending"
+                    },
+                    "decision": {
+                        "type": "string",
+                        "description": "Final decision, may be one of the value (undecided, approved, or denied)",
+                        "enum": [
+                            "undecided",
+                            "approved",
+                            "denied"
+                        ],
+                        "default": "undecided"
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Comments for requests"
+                    },
+                    "workflow_id": {
+                        "type": "string",
+                        "description": "Associate workflow id"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of last update"
+                    },
+                    "active_stage": {
+                        "type": "integer",
+                        "description": "Current (or last) active stage. For regular approver this number is always 0"
+                    },
+                    "total_stages": {
+                        "type": "integer",
+                        "description": "Total number of stages. For regular approver this number is always 0."
+                    }
+                }
             },
             "StageOut": {
                 "type": "object",
@@ -1247,18 +1273,18 @@
                         "$ref": "#/components/schemas/WorkflowIn"
                     },
                     {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string"
-                            },
-                            "template_id": {
-                                "type": "string",
-                                "description": "Associated template id"
-                            }
-                        }
+                      "type": "object"
                     }
-                ]
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "template_id": {
+                        "type": "string",
+                        "description": "Associated template id"
+                    }
+                }
             },
             "ActionOutCollection": {
                 "type": "object",

--- a/spec/requests/v1.0/workflows_spec.rb
+++ b/spec/requests/v1.0/workflows_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe 'Workflows API' do
     end
   end
 
+  describe "GET /workflows with filter" do
+    before do
+      get "#{api_version}/workflows?filter[id]=#{id}", :params => { :limit => 5, :offset => 0 }, :headers => request_header
+    end
+
+    it 'returns only the filtered result' do
+      expect(json["meta"]["count"]).to eq 1
+      expect(json["data"].first["id"]).to eq id.to_s
+    end
+  end
+
   describe 'GET /workflows/:id' do
     before { get "#{api_version}/workflows/#{id}", :headers => request_header }
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-307

Adds filtering on the index methods via ManageIQ::API::Common::Filter.

- [x] fix tests
- [x] add docs https://github.com/ManageIQ/manageiq-api-common/pull/57