### PR TITLE
Add default_scope to Request model to sort by created_at, descending

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -17,6 +17,7 @@ class Request < ApplicationRecord
   scope :decision,  ->(decision)  { where(:decision => decision) }
   scope :state,     ->(state)     { where(:state => state) }
   scope :requester, ->(requester) { where(:requester => requester) }
+  default_scope { order(:created_at => :desc) }
 
   before_create :set_context
 


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-321

Add a default scope to Request so that it returns the models ordered descending by `created_at`, so it shows the newest ones first.