### PR TITLE
Fixed error messages in public web page

### DIFF
--- a/app/controllers/api/v1x0/stageaction/result.html.erb
+++ b/app/controllers/api/v1x0/stageaction/result.html.erb
@@ -16,8 +16,12 @@
         <font face="verdana"><br>
           <font size="22" color="red"><b><%= @resources[:approval_web_product] %></font><hr>
             <% if response.status != 200 %>
-              <h1 font size="24">Unable to complete action [<%= params[:commit] %>]</h1>
-            <p><strong>Reason:</strong><%= response.body %></p>
+              <% if params[:commit] %>
+                <h1 font size="24">Unable to complete action [<%= params[:commit] %>]</h1>
+              <% else %>
+                <h1 font size="24">Unable to complete the action</h1>
+              <% end %>
+              <p><strong>Reason: </strong><%= response.body %></p>
             <% else %>
               <h1 font size="24">Your action [<%= params[:commit] %>] has been recorded.</h1>
             <% end %>

--- a/app/controllers/api/v1x0/stageaction_controller.rb
+++ b/app/controllers/api/v1x0/stageaction_controller.rb
@@ -38,9 +38,9 @@ module Api
         ManageIQ::API::Common::Request.with_request(@stage.request.context.transform_keys(&:to_sym)) do
           ActsAsTenant.with_tenant(Tenant.find(@stage.tenant_id)) do
             ActionCreateService.new(@stage.id).create(
-              'operation'    => operation.downcase,
-              'processed_by' => @approver,
-              'comments'     => comments
+              :operation    => operation.downcase,
+              :processed_by => @approver,
+              :comments     => comments
             )
           end
         end
@@ -60,9 +60,12 @@ module Api
         if @stage
           @order = set_order
         else
-          response.body = "Your request [#{params[:id]}] is either expired or has been processed!"
+          response.body = "Your request is either expired or has been processed!"
           render :status => :internal_server_error, :action => :result
         end
+      rescue ActionController::ParameterMissing => e
+        response.body = e.message
+        render :status => :internal_server_error, :action => :result
       end
 
       def set_order


### PR DESCRIPTION
In the public link provided in email. if no valid random_access_key is given, or approver is missing in the parameter list, the error page will display meaningless error message.

This PR corrects the error message as:
1. Show `Your request is either expired or has been processed!` if random_access_key is empty or invalid;
2. Show `param is missing or the value is empty: approver` if approver is missing in the params list;

Also removed the empty bracket `action []` if no action is executed.