### PR TITLE
Bump manageiq-loggers version to pick up request_id changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem 'acts_as_tenant'
 gem 'jbuilder',           '~> 2.0'
-gem 'manageiq-loggers',   '~> 0.1'
+gem 'manageiq-loggers',   '~> 0.2'
 gem 'manageiq-messaging', '~> 0.1'
 gem 'pg',                 '~> 1.0', :require => false
 gem 'prometheus-client',  '~> 0.8.0'


### PR DESCRIPTION
Logging will now include thread local request_id when available.

See https://github.com/ManageIQ/manageiq-loggers/pull/7 (Get the request id from the thread local variable and log it)