### PR TITLE
Return 403 when trying to delete default workflow

### DIFF
--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -25,11 +25,15 @@ module Api
       end
 
       def destroy
-        Workflow.find(params.require(:id)).destroy
-
+        workflow = Workflow.find(params.require(:id))
+        workflow.destroy!
         head :no_content
       rescue ActiveRecord::InvalidForeignKey => e
         json_response({ :message => e.message }, :forbidden)
+      rescue ActiveRecord::RecordNotDestroyed
+        raise unless workflow.errors[:base].include?(Workflow::MSG_PROTECTED_RECORD)
+
+        json_response({ :message => Workflow::MSG_PROTECTED_RECORD }, :forbidden)
       end
 
       def update

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -9,6 +9,8 @@ class Workflow < ApplicationRecord
 
   before_destroy :protect_default
 
+  MSG_PROTECTED_RECORD = "This workflow is protected from being deleted".freeze
+
   def self.seed
     workflow = find_or_create_by!(default_workflow_query)
     workflow.update_attributes!(
@@ -42,6 +44,9 @@ class Workflow < ApplicationRecord
   private
 
   def protect_default
-    throw :abort if self.class.send(:default_workflow_query) == {:name => name, :template => template}
+    if self.class.send(:default_workflow_query) == {:name => name, :template => template}
+      errors.add(:base, MSG_PROTECTED_RECORD)
+      throw :abort
+    end
   end
 end

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -170,6 +170,19 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     end
   end
 
+  describe 'DELETE /workflows/:id of default workflow' do
+    before do
+      Workflow.seed
+      delete "#{api_version}/workflows/#{Workflow.default_workflow.id}", :headers => request_header
+    end
+
+    after { Workflow.instance_variable_set(:@default_workflow, nil) }
+
+    it 'returns status code 403' do
+      expect(response).to have_http_status(403)
+    end
+  end
+
   describe 'Entitlement enforcement' do
     let(:false_hash) do
       false_hash = default_user_hash

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe Workflow, :type => :model do
 
     it 'cannot be destroyed' do
       described_class.seed
-      expect { described_class.default_workflow.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      default_workflow = described_class.default_workflow
+      expect { default_workflow.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+      expect(default_workflow.errors[:base]).to include(described_class::MSG_PROTECTED_RECORD)
     end
   end
 


### PR DESCRIPTION
The backend already prevent the default workflow from being deleted but the API still returns success.

Addressed QE test on https://projects.engineering.redhat.com/browse/SSP-330