### PR TITLE
Set the URLs based on the topology openapi.json

### DIFF
--- a/public/approval/v1.0/openapi.json
+++ b/public/approval/v1.0/openapi.json
@@ -880,7 +880,25 @@
     ],
     "servers": [
         {
-            "url": "http://localhost/api/approval/v1.0"
+            "url": "https://cloud.redhat.com/{basePath}",
+            "description": "Production Server",
+            "variables": {
+                "basePath": {
+                    "default": "/api/approval/v1.0"
+                }
+            }
+        },
+        {
+            "url": "http://localhost:{port}/{basePath}",
+            "description": "Development Server",
+            "variables": {
+                "port": {
+                    "default": "3000"
+                },
+                "basePath": {
+                    "default": "/api/approval/v1.0"
+                }
+            }
         }
     ],
     "components": {


### PR DESCRIPTION
Keeps us in sync with the topology and catalog URLs which have the production and development servers

Topology: ManageIQ/topological_inventory-api#157
Catalog: ManageIQ/catalog-api#213