### PR TITLE
Backend support of cancel action

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -6,7 +6,8 @@ class Action < ApplicationRecord
   MEMO_OPERATION    = 'memo'.freeze
   APPROVE_OPERATION = 'approve'.freeze
   DENY_OPERATION    = 'deny'.freeze
-  OPERATIONS = [NOTIFY_OPERATION, SKIP_OPERATION, MEMO_OPERATION, APPROVE_OPERATION, DENY_OPERATION].freeze
+  CANCEL_OPERATION  = 'cancel'.freeze
+  OPERATIONS = [NOTIFY_OPERATION, SKIP_OPERATION, MEMO_OPERATION, APPROVE_OPERATION, DENY_OPERATION, CANCEL_OPERATION].freeze
 
   validates :operation, :inclusion => { :in => OPERATIONS }
   validates :processed_by, :presence  => true

--- a/app/models/concerns/approval_decisions.rb
+++ b/app/models/concerns/approval_decisions.rb
@@ -2,5 +2,6 @@ module ApprovalDecisions
   UNDECIDED_STATUS = 'undecided'.freeze
   APPROVED_STATUS  = 'approved'.freeze
   DENIED_STATUS    = 'denied'.freeze
-  DECISIONS = [UNDECIDED_STATUS, APPROVED_STATUS, DENIED_STATUS].freeze
+  CANCELED_STATUS  = 'canceled'.freeze
+  DECISIONS = [UNDECIDED_STATUS, APPROVED_STATUS, DENIED_STATUS, CANCELED_STATUS].freeze
 end

--- a/app/models/concerns/approval_states.rb
+++ b/app/models/concerns/approval_states.rb
@@ -3,5 +3,6 @@ module ApprovalStates
   SKIPPED_STATE  = 'skipped'.freeze
   NOTIFIED_STATE = 'notified'.freeze
   FINISHED_STATE = 'finished'.freeze
-  STATES = [PENDING_STATE, SKIPPED_STATE, NOTIFIED_STATE, FINISHED_STATE].freeze
+  CANCELED_STATE = 'canceled'.freeze
+  STATES = [PENDING_STATE, SKIPPED_STATE, NOTIFIED_STATE, FINISHED_STATE, CANCELED_STATE].freeze
 end

--- a/app/services/action_create_service.rb
+++ b/app/services/action_create_service.rb
@@ -70,4 +70,14 @@ class ActionCreateService
 
     {:state => Stage::FINISHED_STATE, :decision => Stage::DENIED_STATUS, :reason => comments}
   end
+
+  def cancel(comments)
+    unless [Stage::PENDING_STATE, Stage::NOTIFIED_STATE].include?(stage.state)
+      raise Exceptions::InvalidStateTransitionError, "Current stage has already finished"
+    end
+
+    {:state => Stage::CANCELED_STATE}.tap do |h|
+      h[:reason] = comments if comments
+    end
+  end
 end

--- a/app/services/action_create_service.rb
+++ b/app/services/action_create_service.rb
@@ -76,7 +76,7 @@ class ActionCreateService
       raise Exceptions::InvalidStateTransitionError, "Current stage has already finished"
     end
 
-    {:state => Stage::CANCELED_STATE}.tap do |h|
+    {:state => Stage::CANCELED_STATE, :decision => Stage::CANCELED_STATUS}.tap do |h|
       h[:reason] = comments if comments
     end
   end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -3,6 +3,7 @@ require 'manageiq-messaging'
 class EventService
   EVENT_REQUEST_STARTED  = 'request_started'.freeze
   EVENT_REQUEST_FINISHED = 'request_finished'.freeze
+  EVENT_REQUEST_CANCELED = 'request_canceled'.freeze
   EVENT_APPROVER_GROUP_NOTIFIED = 'approver_group_notified'.freeze
   EVENT_APPROVER_GROUP_FINISHED = 'approver_group_finished'.freeze
   EVENT_SENDER = 'approval_service'.freeze
@@ -35,6 +36,12 @@ class EventService
     send_event(EVENT_REQUEST_FINISHED,
                :request_id => request.id,
                :decision   => request.decision,
+               :reason     => request.reason || '')
+  end
+
+  def request_canceled
+    send_event(EVENT_REQUEST_CANCELED,
+               :request_id => request.id,
                :reason     => request.reason || '')
   end
 

--- a/app/services/request_update_service.rb
+++ b/app/services/request_update_service.rb
@@ -14,6 +14,8 @@ class RequestUpdateService
       EventService.new(request).request_started
     when Request::FINISHED_STATE
       EventService.new(request).request_finished
+    when Request::CANCELED_STATE
+      EventService.new(request).request_canceled
     end
   end
 end

--- a/app/services/stage_update_service.rb
+++ b/app/services/stage_update_service.rb
@@ -20,6 +20,9 @@ class StageUpdateService
       request_finished(stage.decision, stage.reason) if last_stage?
     when Stage::SKIPPED_STATE
       last_stage_skipped if last_stage?
+    when Stage::CANCELED_STATE
+      stage_finished('canceled')
+      request_canceled(stage.reason) if last_stage?
     end
   end
 
@@ -38,14 +41,15 @@ class StageUpdateService
   end
 
   def last_stage_skipped
-    last_decision = nil
-    last_reason   = nil
-    stage.request.stages.each do |st|
+    stage.request.stages.reverse_each do |st|
       next if st.state == Stage::SKIPPED_STATE
-      last_decision = st.decision
-      last_reason   = st.reason
+      if st.state == Stage::CANCELED_STATE
+        request_canceled(st.reason)
+      else
+        request_finished(st.decision, st.reason)
+      end
+      break
     end
-    request_finished(last_decision, last_reason)
   end
 
   def request_finished(last_decision, last_reason)
@@ -53,6 +57,13 @@ class StageUpdateService
       :state    => Request::FINISHED_STATE,
       :decision => last_decision,
       :reason   => last_reason
+    )
+  end
+
+  def request_canceled(reason)
+    RequestUpdateService.new(stage.request.id).update(
+      :state  => Request::CANCELED_STATE,
+      :reason => reason
     )
   end
 
@@ -69,7 +80,7 @@ class StageUpdateService
     next_stage = stage.request.stages.find { |s| s.state == Stage::PENDING_STATE }
     return unless next_stage
 
-    operation = decision == Stage::DENIED_STATUS ? Action::SKIP_OPERATION : Action::NOTIFY_OPERATION
+    operation = [Stage::DENIED_STATUS, 'canceled'].include?(decision) ? Action::SKIP_OPERATION : Action::NOTIFY_OPERATION
     ActionCreateService.new(next_stage.id).create(:operation => operation, :processed_by => 'system')
   end
 

--- a/app/services/stage_update_service.rb
+++ b/app/services/stage_update_service.rb
@@ -21,7 +21,7 @@ class StageUpdateService
     when Stage::SKIPPED_STATE
       last_stage_skipped if last_stage?
     when Stage::CANCELED_STATE
-      stage_finished('canceled')
+      stage_finished(Stage::CANCELED_STATUS)
       request_canceled(stage.reason) if last_stage?
     end
   end
@@ -62,8 +62,9 @@ class StageUpdateService
 
   def request_canceled(reason)
     RequestUpdateService.new(stage.request.id).update(
-      :state  => Request::CANCELED_STATE,
-      :reason => reason
+      :state    => Request::CANCELED_STATE,
+      :decision => Request::CANCELED_STATUS,
+      :reason   => reason
     )
   end
 
@@ -80,7 +81,7 @@ class StageUpdateService
     next_stage = stage.request.stages.find { |s| s.state == Stage::PENDING_STATE }
     return unless next_stage
 
-    operation = [Stage::DENIED_STATUS, 'canceled'].include?(decision) ? Action::SKIP_OPERATION : Action::NOTIFY_OPERATION
+    operation = [Stage::DENIED_STATUS, Stage::CANCELED_STATE].include?(decision) ? Action::SKIP_OPERATION : Action::NOTIFY_OPERATION
     ActionCreateService.new(next_stage.id).create(:operation => operation, :processed_by => 'system')
   end
 

--- a/spec/services/action_create_service_spec.rb
+++ b/spec/services/action_create_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ActionCreateService do
       stage2.reload
       request.reload
       expect(action).to  have_attributes(:operation => Action::DENY_OPERATION, :processed_by => 'man', :comments => 'bad')
-      expect(stage2).to  have_attributes(:state => Stage::FINISHED_STATE,   :decision => Stage::DENIED_STATUS, :reason => 'bad')
+      expect(stage2).to  have_attributes(:state => Stage::FINISHED_STATE,   :decision => Stage::DENIED_STATUS,   :reason => 'bad')
       expect(request).to have_attributes(:state => Request::FINISHED_STATE, :decision => Request::DENIED_STATUS, :reason => 'bad')
     end
   end
@@ -61,9 +61,9 @@ RSpec.describe ActionCreateService do
       stage2.reload
       request.reload
       expect(action1).to have_attributes(:operation => Action::DENY_OPERATION, :processed_by => 'man', :comments => 'bad')
-      expect(stage1).to  have_attributes(:state => Stage::FINISHED_STATE,   :decision => Stage::DENIED_STATUS, :reason => 'bad')
+      expect(stage1).to  have_attributes(:state => Stage::FINISHED_STATE,   :decision => Stage::DENIED_STATUS,    :reason => 'bad')
       expect(stage2).to  have_attributes(:state => Stage::SKIPPED_STATE,    :decision => Stage::UNDECIDED_STATUS, :reason => nil)
-      expect(request).to have_attributes(:state => Request::FINISHED_STATE, :decision => Request::DENIED_STATUS, :reason => 'bad')
+      expect(request).to have_attributes(:state => Request::FINISHED_STATE, :decision => Request::DENIED_STATUS,  :reason => 'bad')
     end
   end
 
@@ -75,9 +75,9 @@ RSpec.describe ActionCreateService do
       stage2.reload
       request.reload
       expect(action1).to have_attributes(:operation => Action::CANCEL_OPERATION, :processed_by => 'requester', :comments => 'regret')
-      expect(stage1).to  have_attributes(:state => Stage::CANCELED_STATE,   :decision => Stage::UNDECIDED_STATUS, :reason => 'regret')
-      expect(stage2).to  have_attributes(:state => Stage::SKIPPED_STATE,    :decision => Stage::UNDECIDED_STATUS, :reason => nil)
-      expect(request).to have_attributes(:state => Request::CANCELED_STATE, :decision => Request::UNDECIDED_STATUS, :reason => 'regret')
+      expect(stage1).to  have_attributes(:state => Stage::CANCELED_STATE,   :decision => Stage::CANCELED_STATUS,   :reason => 'regret')
+      expect(stage2).to  have_attributes(:state => Stage::SKIPPED_STATE,    :decision => Stage::UNDECIDED_STATUS,  :reason => nil)
+      expect(request).to have_attributes(:state => Request::CANCELED_STATE, :decision => Request::CANCELED_STATUS, :reason => 'regret')
     end
   end
 

--- a/spec/services/event_service_spec.rb
+++ b/spec/services/event_service_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe EventService do
     subject.request_finished
   end
 
+  it 'sends request_canceled event' do
+    expect(subject).to receive(:send_event).with(described_class::EVENT_REQUEST_CANCELED, hash_including(:request_id, :reason))
+    subject.request_canceled
+  end
+
   it 'sends approver_group_notified event' do
     expect(subject).to receive(:send_event).with(described_class::EVENT_APPROVER_GROUP_NOTIFIED, hash_including(:request_id, :group_name))
     subject.approver_group_notified(stage)

--- a/spec/services/request_update_service_spec.rb
+++ b/spec/services/request_update_service_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe RequestUpdateService do
     end
   end
 
+  context 'state becomes canceled' do
+    it 'sends request_canceled event' do
+      expect(event_service).to receive(:request_canceled)
+      subject.update(:state => Request::CANCELED_STATE)
+      request.reload
+      expect(request.state).to eq(Request::CANCELED_STATE)
+    end
+  end
+
   context 'state unchanged' do
     it 'sends no events' do
       expect(event_service).not_to receive(:request_started)


### PR DESCRIPTION
Adding new action type `cancel`.
When cancel action is added to a stage, it cancels the stage and eventually cancels the request.
When a request is canceled, it sends `request_canceled` event to the message bus.

@hsong-rh please add new endpoint `POST /requests/<id>/actions`. We will discuss wither to retire `POST /stages/<id>/actions`