### PR TITLE
Modify as_json to only expose what is configured in the OpenAPI Spec

### DIFF
--- a/lib/open_api/serializer.rb
+++ b/lib/open_api/serializer.rb
@@ -1,14 +1,43 @@
 module OpenApi
   module Serializer
     def as_json(arg = {})
-      return super unless kind_of?(ApplicationRecord)
+      previous = super
+      encrypted_columns_set = (self.class.try(:encrypted_columns) || []).to_set
+      encryption_filtered = previous.except(*encrypted_columns_set)
+      version = version_from_path(arg)
 
-      super.tap do |hash|
-        hash.each_key do |attr_key|
-          hash[attr_key] = hash[attr_key].iso8601 if hash[attr_key].kind_of?(Time)
-          hash[attr_key] = hash[attr_key].to_s if attr_key.ends_with?("_id") || attr_key == "id"
-        end
+      return encryption_filtered unless arg.key?(:prefixes) || version
+
+      # We use "#{klass.name}Out" for the definitions on what are returned.
+      schema = Api::Docs[version].definitions[self.class.name + "Out"]
+
+      filter(encryption_filtered.slice(*schema["properties"].keys), schema, encrypted_columns_set)
+    end
+
+    private
+
+    def version_from_path(arg)
+      url = ManageIQ::API::Common::Request.current.instance_variable_get(:@original_url) || nil
+      base_path = url ? URI.parse(url).path : arg[:prefixes].first
+      api_version_from_prefix(base_path)
+    end
+
+    def filter(attrs, schema, encrypted_columns_set)
+      schema["properties"].keys.each do |name|
+        next if attrs[name].nil?
+
+        attrs[name] = attrs[name].iso8601 if attrs[name].kind_of?(Time)
+        attrs[name] = attrs[name].to_s if name.ends_with?("_id") || name == "id"
+        attrs[name] = public_send(name) if !attrs.key?(name) && !encrypted_columns_set.include?(name)
       end
+      attrs.compact
+    end
+
+    def api_version_from_prefix(prefix)
+      return unless prefix
+
+      /\/?\w+\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ prefix
+      [major, minor].compact.join(".")
     end
   end
 end

--- a/public/approval/v1.0/openapi.json
+++ b/public/approval/v1.0/openapi.json
@@ -1053,11 +1053,6 @@
                     "id": {
                         "type": "string"
                     },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Timestamp of creation"
-                    },
                     "stage_id": {
                         "type": "string",
                         "description": "Associated stage id"
@@ -1082,6 +1077,16 @@
                         "type": "string",
                         "description": "Comments for action",
                         "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of last update"
                     }
                 }
             },
@@ -1222,6 +1227,16 @@
                     "notified_at": {
                         "type": "string",
                         "description": "the time approvers in the stage are notified"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of last update"
                     }
                 }
             },
@@ -1237,6 +1252,16 @@
                     },
                     "description": {
                         "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of last update"
                     }
                 }
             },
@@ -1285,6 +1310,16 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of creation"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp of last update"
                     }
                 }
             },

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
   let!(:workflow) { create(:workflow, :name => 'Test always approve') } #:template_id => template.id) }
   let(:workflow_id) { workflow.id }
   let!(:requests) do
-    ManageIQ::API::Common::Request.with_request(:headers => request_header, :original_url => "localhost/approval") do
+    ManageIQ::API::Common::Request.with_request(RequestSpecHelper.default_request_hash) do
       create_list(:request, 2, :workflow_id => workflow.id, :tenant_id => tenant.id)
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -5,6 +5,12 @@ RSpec.describe Request, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:content) }
 
+  around do |example|
+    ManageIQ::API::Common::Request.with_request(RequestSpecHelper.default_request_hash) do
+      example.call
+    end
+  end
+
   describe '#as_json' do
     subject { FactoryBot.create(:request, :stages => stages) }
 

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -69,6 +69,6 @@ module RequestSpecHelper
   end
 
   def default_request_hash
-    {:headers => default_headers, :original_url => 'https://xyz.com/api/requests'}
+    {:headers => default_headers, :original_url => 'https://xyz.com/api/v1.0/requests'}
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-476

This PR modifies `as_json` to return in the response only what is in the OpenAPI Spec.
Largely an implementation of what we did on Catalog here:
 https://github.com/ManageIQ/catalog-api/pull/298 