### PR TITLE
Remove Basic_auth from openapi because the backend does not support it

### DIFF
--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -917,11 +917,6 @@
             }
         }
     },
-    "security": [
-        {
-            "Basic_auth": []
-        }
-    ],
     "servers": [
         {
             "url": "https://cloud.redhat.com/{basePath}",

--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'when request is actionable' do
-      let!(:stage1) { create(:stage, :id => "1", :state => Stage::NOTIFIED_STATE, :request => req, :tenant_id => tenant.id) }
-      let!(:stage2) { create(:stage, :id => "2", :state => Stage::PENDING_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage1) { create(:stage, :state => Stage::NOTIFIED_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage2) { create(:stage, :state => Stage::PENDING_STATE, :request => req, :tenant_id => tenant.id) }
       let(:valid_attributes) { { :operation => 'cancel', :processed_by => 'abcd' } }
 
       it 'returns status code 201' do
@@ -80,8 +80,8 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'when request is not actionable' do
-      let!(:stage1) { create(:stage, :id => "1", :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
-      let!(:stage2) { create(:stage, :id => "2", :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage1) { create(:stage, :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage2) { create(:stage, :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
       let(:valid_attributes) { { :operation => 'notify', :processed_by => 'abcd' } }
 
       it 'returns status code 500' do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Request, type: :model do
 
     context 'all stages are pending or notified' do
       let(:stages) do
-        [FactoryBot.create(:stage, :id => 1, :state => Stage::NOTIFIED_STATE),
-         FactoryBot.create(:stage, :id => 2, :state => Stage::PENDING_STATE),
-         FactoryBot.create(:stage, :id => 3, :state => Stage::PENDING_STATE)]
+        [FactoryBot.create(:stage, :state => Stage::NOTIFIED_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE)]
       end
 
-      it 'has active_stage pointing to the last stage' do
+      it 'has active_stage pointing to the first stage' do
         expect(subject.as_json).to include(:active_stage => 1, :total_stages => 3)
-        expect(subject.current_stage.id).to eq(1)
+        expect(subject.current_stage.id).to eq(stages[0].id)
       end
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Request, type: :model do
          FactoryBot.create(:stage, :state => Stage::SKIPPED_STATE)]
       end
 
-      it 'has active_stage pointing to the first stage' do
+      it 'has active_stage pointing to the last stage' do
         expect(subject.as_json).to include(:active_stage => 3, :total_stages => 3)
         expect(subject.current_stage).to be_nil
       end
@@ -36,14 +36,14 @@ RSpec.describe Request, type: :model do
 
     context 'some stage is active' do
       let(:stages) do
-        [FactoryBot.create(:stage, :id => 1, :state => Stage::FINISHED_STATE),
-         FactoryBot.create(:stage, :id => 2, :state => Stage::PENDING_STATE),
-         FactoryBot.create(:stage, :id => 3, :state => Stage::PENDING_STATE)]
+        [FactoryBot.create(:stage, :state => Stage::FINISHED_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE)]
       end
 
-      it 'has active_stage pointing to the first stage' do
+      it 'has active_stage pointing to the first pending stage' do
         expect(subject.as_json).to include(:active_stage => 2, :total_stages => 3)
-        expect(subject.current_stage.id).to eq(2)
+        expect(subject.current_stage.id).to eq(stages[1].id)
       end
     end
   end


### PR DESCRIPTION
It actually causes trouble in the client used by QE.