### PR TITLE
Added OwnerField to Request model

### DIFF
--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -28,7 +28,7 @@ module Api
       private
 
       def request_params
-        params.permit(:name, :description, :requester, :content => {})
+        params.permit(:name, :description, :owner, :content => {})
       end
     end
   end

--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -28,7 +28,7 @@ module Api
       private
 
       def request_params
-        params.permit(:name, :description, :content => {})
+        params.permit(:name, :description, :requester_name, :content => {})
       end
     end
   end

--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -28,7 +28,7 @@ module Api
       private
 
       def request_params
-        params.permit(:name, :description, :owner, :content => {})
+        params.permit(:name, :description, :content => {})
       end
     end
   end

--- a/app/controllers/api/v1x0/stageaction_controller.rb
+++ b/app/controllers/api/v1x0/stageaction_controller.rb
@@ -71,7 +71,7 @@ module Api
       def set_order
         request = @stage.request
         {
-          :orderer       => request.requester,
+          :orderer       => request.owner,
           :product       => request.content["product"],
           :portfolio     => request.content["portfolio"],
           :order_id      => request.content["order_id"],

--- a/app/controllers/api/v1x0/stageaction_controller.rb
+++ b/app/controllers/api/v1x0/stageaction_controller.rb
@@ -71,7 +71,7 @@ module Api
       def set_order
         request = @stage.request
         {
-          :orderer       => request.owner,
+          :orderer       => request.requester_name,
           :product       => request.content["product"],
           :portfolio     => request.content["portfolio"],
           :order_id      => request.content["order_id"],

--- a/app/models/concerns/owner_field.rb
+++ b/app/models/concerns/owner_field.rb
@@ -1,0 +1,14 @@
+module OwnerField
+  extend ActiveSupport::Concern
+
+  included do
+    validates :owner, :presence => true, :on => :create
+
+    before_validation :set_owner, :if => proc { ManageIQ::API::Common::Request.current.present? }, :on => :create
+    scope :by_owner, -> { where('owner = ?', ManageIQ::API::Common::Request.current.user.username) }
+  end
+
+  def set_owner
+    self.owner = ManageIQ::API::Common::Request.current.user.username
+  end
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,6 +1,7 @@
 class Request < ApplicationRecord
   include ApprovalStates
   include ApprovalDecisions
+  include OwnerField
 
   acts_as_tenant(:tenant)
 
@@ -15,7 +16,7 @@ class Request < ApplicationRecord
 
   scope :decision,  ->(decision)  { where(:decision => decision) }
   scope :state,     ->(state)     { where(:state => state) }
-  scope :requester, ->(requester) { where(:requester => requester) }
+  scope :owner,     ->(owner)     { where(:owner => owner) }
   default_scope { order(:created_at => :desc) }
 
   before_create :set_context

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -14,9 +14,9 @@ class Request < ApplicationRecord
   validates :state,    :inclusion => { :in => STATES }
   validates :decision, :inclusion => { :in => DECISIONS }
 
-  scope :decision,  ->(decision)  { where(:decision => decision) }
-  scope :state,     ->(state)     { where(:state => state) }
-  scope :owner,     ->(owner)     { where(:owner => owner) }
+  scope :decision, ->(decision) { where(:decision => decision) }
+  scope :state,    ->(state)    { where(:state => state) }
+  scope :owner,    ->(owner)    { where(:owner => owner) }
   default_scope { order(:created_at => :desc) }
 
   before_create :set_context

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -14,9 +14,10 @@ class Request < ApplicationRecord
   validates :state,    :inclusion => { :in => STATES }
   validates :decision, :inclusion => { :in => DECISIONS }
 
-  scope :decision, ->(decision) { where(:decision => decision) }
-  scope :state,    ->(state)    { where(:state => state) }
-  scope :owner,    ->(owner)    { where(:owner => owner) }
+  scope :decision,       ->(decision)       { where(:decision => decision) }
+  scope :state,          ->(state)          { where(:state => state) }
+  scope :owner,          ->(owner)          { where(:owner => owner) }
+  scope :requester_name, ->(requester_name) { where(:requester_name => requester_name) }
   default_scope { order(:created_at => :desc) }
 
   before_create :set_context

--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -25,6 +25,11 @@ class RequestCreateService
       :stages   => stages
     )
 
+    unless options[:requester_name]
+      requester = ManageIQ::API::Common::Request.current.user
+      create_options[:requester_name] = "#{requester.first_name} #{requester.last_name}"
+    end
+
     Request.create!(create_options).tap do |request|
       if default_approve? || auto_approve?
         start_internal_approval_process(request)

--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -25,11 +25,6 @@ class RequestCreateService
       :stages   => stages
     )
 
-    unless options[:requester]
-      requester = ManageIQ::API::Common::Request.current.user
-      create_options[:requester] = "#{requester.first_name} #{requester.last_name}"
-    end
-
     Request.create!(create_options).tap do |request|
       if default_approve? || auto_approve?
         start_internal_approval_process(request)

--- a/db/migrate/20190612021005_add_owner_to_requests.rb
+++ b/db/migrate/20190612021005_add_owner_to_requests.rb
@@ -1,0 +1,6 @@
+class AddOwnerToRequests < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :requests, :requester, :requester_name
+    add_column :requests, :owner, :string
+  end
+end

--- a/db/migrate/20190612021005_rename_requester_to_owner.rb
+++ b/db/migrate/20190612021005_rename_requester_to_owner.rb
@@ -1,5 +1,0 @@
-class RenameRequesterToOwner < ActiveRecord::Migration[5.2]
-  def change
-    rename_column :requests, :requester, :owner
-  end
-end

--- a/db/migrate/20190612021005_rename_requester_to_owner.rb
+++ b/db/migrate/20190612021005_rename_requester_to_owner.rb
@@ -1,0 +1,5 @@
+class RenameRequesterToOwner < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :requests, :requester, :owner
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_03_173445) do
+ActiveRecord::Schema.define(version: 2019_06_12_021005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2019_04_03_173445) do
   end
 
   create_table "requests", force: :cascade do |t|
-    t.string "requester"
+    t.string "owner"
     t.string "name"
     t.string "description"
     t.string "state"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_021005) do
   end
 
   create_table "requests", force: :cascade do |t|
-    t.string "owner"
+    t.string "requester_name"
     t.string "name"
     t.string "description"
     t.string "state"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_021005) do
     t.bigint "tenant_id"
     t.string "process_ref"
     t.jsonb "context"
+    t.string "owner"
     t.index ["tenant_id"], name: "index_requests_on_tenant_id"
     t.index ["workflow_id"], name: "index_requests_on_workflow_id"
   end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1148,10 +1148,6 @@
                     "content"
                 ],
                 "properties": {
-                    "owner": {
-                        "type": "string",
-                        "description": "Owner id"
-                    },
                     "name": {
                         "type": "string",
                         "description": "Request name"

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1148,9 +1148,9 @@
                     "content"
                 ],
                 "properties": {
-                    "requester": {
+                    "owner": {
                         "type": "string",
-                        "description": "Requester id"
+                        "description": "Owner id"
                     },
                     "name": {
                         "type": "string",
@@ -1222,9 +1222,9 @@
                         "type": "integer",
                         "description": "Total number of stages. For regular approver this number is always 0."
                     },
-                    "requester": {
+                    "owner": {
                         "type": "string",
-                        "description": "Requester id"
+                        "description": "Owner id"
                     },
                     "name": {
                         "type": "string",

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1148,6 +1148,10 @@
                     "content"
                 ],
                 "properties": {
+                    "requester_name": {
+                        "type": "string",
+                        "description": "Requester id"
+                    },
                     "name": {
                         "type": "string",
                         "description": "Request name"
@@ -1221,6 +1225,10 @@
                     "owner": {
                         "type": "string",
                         "description": "Owner id"
+                    },
+                    "requester_name": {
+                        "type": "string",
+                        "description": "Requester name"
                     },
                     "name": {
                         "type": "string",

--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -66,8 +66,8 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'when request is actionable' do
-      let!(:stage1) { create(:stage, :id => "1", :state => Stage::NOTIFIED_STATE, :request => req, :tenant_id => tenant.id) }
-      let!(:stage2) { create(:stage, :id => "2", :state => Stage::PENDING_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage1) { create(:stage, :state => Stage::NOTIFIED_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage2) { create(:stage, :state => Stage::PENDING_STATE, :request => req, :tenant_id => tenant.id) }
       let(:valid_attributes) { { :operation => 'cancel', :processed_by => 'abcd' } }
 
       it 'returns status code 201' do
@@ -80,8 +80,8 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
     end
 
     context 'when request is not actionable' do
-      let!(:stage1) { create(:stage, :id => "1", :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
-      let!(:stage2) { create(:stage, :id => "2", :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage1) { create(:stage, :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
+      let!(:stage2) { create(:stage, :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
       let(:valid_attributes) { { :operation => 'notify', :processed_by => 'abcd' } }
 
       it 'returns status code 500' do

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
   # Test suite for POST /workflows/:workflow_id/requests
   describe 'POST /workflows/:workflow_id/requests' do
     let(:item) { { 'disk' => '100GB' } }
-    let(:valid_attributes) { { :requester => '1234', :name => 'Visit Narnia', :content => item, :description => 'desc' } }
+    let(:valid_attributes) { { :name => 'Visit Narnia', :content => item, :description => 'desc' } }
 
     context 'when request attributes are valid' do
       before do
@@ -176,7 +176,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
 
       it 'returns status code 201' do
         expect(response).to have_http_status(201)
-        expect(json).to include('requester' => '1234', 'name' => 'Visit Narnia', 'content' => item, 'description' => 'desc')
+        expect(json).to include('name' => 'Visit Narnia', 'content' => item, 'description' => 'desc')
       end
     end
   end

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
   # Test suite for POST /workflows/:workflow_id/requests
   describe 'POST /workflows/:workflow_id/requests' do
     let(:item) { { 'disk' => '100GB' } }
-    let(:valid_attributes) { { :name => 'Visit Narnia', :content => item, :description => 'desc' } }
+    let(:valid_attributes) { { :requester_name => '1234', :name => 'Visit Narnia', :content => item, :description => 'desc' } }
 
     context 'when request attributes are valid' do
       before do
@@ -176,7 +176,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
 
       it 'returns status code 201' do
         expect(response).to have_http_status(201)
-        expect(json).to include('name' => 'Visit Narnia', 'content' => item, 'description' => 'desc')
+        expect(json).to include('requester_name' => '1234', 'name' => 'Visit Narnia', 'content' => item, 'description' => 'desc')
       end
     end
   end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -3,11 +3,12 @@ FactoryBot.define do
   factory :request do
     items = { Faker::Lorem.word   => Faker::Lorem.word,
              Faker::Lorem.word   => Faker::Lorem.word }
-    name         { Faker::Lorem.word }
-    owner        { Faker::Lorem.word }
-    content      { JSON.generate(items) }
-    state        { :pending }
-    decision     { :undecided }
+    name           { Faker::Lorem.word }
+    requester_name { Faker::Lorem.word }
+    owner          { Faker::Lorem.word }
+    content        { JSON.generate(items) }
+    state          { :pending }
+    decision       { :undecided }
 
     workflow
 

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     items = { Faker::Lorem.word   => Faker::Lorem.word,
              Faker::Lorem.word   => Faker::Lorem.word }
     name         { Faker::Lorem.word }
-    requester    { Faker::Lorem.word }
+    owner        { Faker::Lorem.word }
     content      { JSON.generate(items) }
     state        { :pending }
     decision     { :undecided }

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Request, type: :model do
 
     context 'all stages are pending or notified' do
       let(:stages) do
-        [FactoryBot.create(:stage, :id => 1, :state => Stage::NOTIFIED_STATE),
-         FactoryBot.create(:stage, :id => 2, :state => Stage::PENDING_STATE),
-         FactoryBot.create(:stage, :id => 3, :state => Stage::PENDING_STATE)]
+        [FactoryBot.create(:stage, :state => Stage::NOTIFIED_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE)]
       end
 
-      it 'has active_stage pointing to the last stage' do
+      it 'has active_stage pointing to the first stage' do
         expect(subject.as_json).to include(:active_stage => 1, :total_stages => 3)
-        expect(subject.current_stage.id).to eq(1)
+        expect(subject.current_stage.id).to eq(stages[0].id)
       end
     end
 
@@ -36,14 +36,14 @@ RSpec.describe Request, type: :model do
 
     context 'some stage is active' do
       let(:stages) do
-        [FactoryBot.create(:stage, :id => 1, :state => Stage::FINISHED_STATE),
-         FactoryBot.create(:stage, :id => 2, :state => Stage::PENDING_STATE),
-         FactoryBot.create(:stage, :id => 3, :state => Stage::PENDING_STATE)]
+        [FactoryBot.create(:stage, :state => Stage::FINISHED_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE),
+         FactoryBot.create(:stage, :state => Stage::PENDING_STATE)]
       end
 
       it 'has active_stage pointing to the first stage' do
         expect(subject.as_json).to include(:active_stage => 2, :total_stages => 3)
-        expect(subject.current_stage.id).to eq(2)
+        expect(subject.current_stage.id).to eq(stages[1].id)
       end
     end
   end

--- a/spec/services/request_create_service_spec.rb
+++ b/spec/services/request_create_service_spec.rb
@@ -12,20 +12,36 @@ RSpec.describe RequestCreateService do
     end
   end
 
+  context 'with auto fill requester' do
+    it 'auto fill requester if it is nil' do
+      request = subject.create(:name => 'req1', :content => 'test me')
+      request.reload
+      expect(request.requester_name).to include(ManageIQ::API::Common::Request.current.user.last_name)
+      expect(request.requester_name).to include(ManageIQ::API::Common::Request.current.user.first_name)
+    end
+
+    it 'skips auto filling if requester is set' do
+      request = subject.create(:name => 'req1', :requester_name => 'test', :content => 'test me')
+      request.reload
+      expect(request.requester_name).to eq("test")
+    end
+  end
+
   context 'without auto approval' do
     context 'template has external process' do
       let(:template) { create(:template, :process_setting => {'processor_type' => 'jbpm', 'url' => 'url'}) }
 
       it 'creates a request and immediately starts' do
         expect(JbpmProcessService).to receive(:new).and_return(double(:jbpm, :start => 100))
-        request = subject.create(:name => 'req1', :content => 'test me')
+        request = subject.create(:name => 'req1', :requester_name => 'test', :content => 'test me')
         request.reload
         expect(request).to have_attributes(
-          :name        => 'req1',
-          :content     => 'test me',
-          :process_ref => '100',
-          :state       => Request::NOTIFIED_STATE,
-          :decision    => Request::UNDECIDED_STATUS
+          :name           => 'req1',
+          :content        => 'test me',
+          :requester_name => 'test',
+          :process_ref    => '100',
+          :state          => Request::NOTIFIED_STATE,
+          :decision       => Request::UNDECIDED_STATUS
         )
         [0, 1].each do |index|
           stage = request.stages[index]
@@ -41,14 +57,15 @@ RSpec.describe RequestCreateService do
 
     context 'template has no external process' do
       it 'creates a request in notified state' do
-        request = subject.create(:name => 'req1', :content => 'test me')
+        request = subject.create(:name => 'req1', :requester_name => 'test', :content => 'test me')
         request.reload
         expect(request).to have_attributes(
-          :name      => 'req1',
-          :content   => 'test me',
-          :owner     => 'jdoe',
-          :state     => Request::NOTIFIED_STATE,
-          :decision  => Request::UNDECIDED_STATUS
+          :name           => 'req1',
+          :content        => 'test me',
+          :requester_name => 'test',
+          :owner          => 'jdoe',
+          :state          => Request::NOTIFIED_STATE,
+          :decision       => Request::UNDECIDED_STATUS
         )
       end
     end
@@ -67,15 +84,16 @@ RSpec.describe RequestCreateService do
     end
 
     it 'creates a request and auto approves' do
-      request = subject.create(:name => 'req1', :content => 'test me')
+      request = subject.create(:name => 'req1', :requester_name => 'test', :content => 'test me')
       request.reload
       expect(request).to have_attributes(
-        :name      => 'req1',
-        :content   => 'test me',
-        :owner     => 'jdoe',
-        :state     => Request::FINISHED_STATE,
-        :decision  => Request::APPROVED_STATUS,
-        :reason    => 'ok'
+        :name           => 'req1',
+        :content        => 'test me',
+        :requester_name => 'test',
+        :owner          => 'jdoe',
+        :state          => Request::FINISHED_STATE,
+        :decision       => Request::APPROVED_STATUS,
+        :reason         => 'ok'
       )
       [0, 1].each do |index|
         stage = request.stages[index]
@@ -111,15 +129,16 @@ RSpec.describe RequestCreateService do
       expect(ContextService).to receive(:new).and_return(context_service)
       expect(context_service).to receive(:with_context).and_yield
 
-      request = subject.create(:name => 'req2', :content => 'test me')
+      request = subject.create(:name => 'req2', :requester_name => 'test', :content => 'test me')
       request.reload
       expect(request).to have_attributes(
-        :name      => 'req2',
-        :content   => 'test me',
-        :owner     => 'jdoe',
-        :state     => Request::FINISHED_STATE,
-        :decision  => Request::APPROVED_STATUS,
-        :reason    => 'System approved'
+        :name           => 'req2',
+        :content        => 'test me',
+        :requester_name => 'test',
+        :owner          => 'jdoe',
+        :state          => Request::FINISHED_STATE,
+        :decision       => Request::APPROVED_STATUS,
+        :reason         => 'System approved'
       )
     end
   end

--- a/spec/services/request_update_service_spec.rb
+++ b/spec/services/request_update_service_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe RequestUpdateService do
     it 'sends no events' do
       expect(event_service).not_to receive(:request_started)
       expect(event_service).not_to receive(:request_finished)
-      subject.update(:requester => 'another')
+      subject.update(:owner => 'another')
       request.reload
-      expect(request.requester).to eq('another')
+      expect(request.owner).to eq('another')
     end
   end
 end


### PR DESCRIPTION
This is the first phase to enable RBAC support in Approval service: renamed attribute `requester` to `owner` in active record `Request`, and populate it with user information whenever request is created.
