### PR TITLE
Added RBAC access acls/roles to service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,8 @@ gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-com
 gem 'rbac-api-client', :git => 'https://github.com/RedHatInsights/insights-rbac-api-client-ruby.git', :branch => "master"
 
 group :development, :test do
-  gem 'simplecov'
   gem 'climate_control'
+  gem 'simplecov'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'rbac-api-client', :git => 'https://github.com/RedHatInsights/insights-rbac-
 
 group :development, :test do
   gem 'simplecov'
+  gem 'climate_control'
 end
 
 group :test do

--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -1,0 +1,115 @@
+module RBAC
+  class Access
+    attr_reader :acls
+    attr_reader :approver_acls
+    attr_reader :owner, :approver, :admin
+
+    def initialize(resource, verb)
+      @resource      = resource
+      @verb          = verb
+      @regexp        = Regexp.new(":(#{@resource}|\\*):(#{@verb}|\\*)")
+      @app_name      = ENV["APP_NAME"] || "approval"
+      @admin         = false
+      @approver      = false
+      @owner         = false
+      @acls          = []
+      @approver_acls = []
+    end
+
+    def process
+      RBAC::Service.call(RBACApiClient::AccessApi) do |api|
+        Rails.logger.info("Fetch access list for #{@app_name}")
+        @acls = RBAC::Service.paginate(api, :get_principal_access, {}, @app_name).select do |item|
+          Rails.logger.info("Found ACL: #{item}")
+          @regexp.match(item.permission)
+        end
+
+        @acls.any? do |item|
+          item.resource_definitions.any? do |rd|
+            @admin = true if rd.attribute_filter.key == 'id' &&
+                             rd.attribute_filter.operation == 'equal' &&
+                             rd.attribute_filter.value == '*'
+            @owner = true if rd.attribute_filter.key == 'owner' &&
+                             rd.attribute_filter.operation == 'equal' &&
+                             rd.attribute_filter.value == '{{username}}'
+          end
+        end
+        @owner = false if @admin
+
+        unless @admin
+          approver_regexp = Regexp.new(":(workflows|\\*):(approve|\\*)")
+          @approver_acls = RBAC::Service.paginate(api, :get_principal_access, {}, @app_name).select do |item|
+            approver_regexp.match(item.permission)
+          end
+          @approver = true if approver_acls.any?
+        end
+      end
+      Rails.logger.info("Role: admin[#{@admin}], approver[#{@approver}], owner[#{@owner}]; accessible?:[#{accessible?}]")
+
+      self
+    end
+
+    def id_list
+      case @resource
+      when "requests"
+        request_ids
+      when "stages"
+        stage_ids
+      when "actions"
+        action_ids
+      else
+        raise Exceptions::NotAuthorizedError, "Not Authorized for #{@resource}"
+      end
+    end
+
+    def accessible?
+      @acls.any?
+    end
+
+    def self.enabled?
+      ENV['BYPASS_RBAC'].blank?
+    end
+
+    def owner?
+      @owner
+    end
+
+    def admin?
+      @admin
+    end
+
+    def approver?
+      @approver
+    end
+
+    private
+
+    def request_ids
+      Request.where(:workflow_id => workflow_ids).pluck(:id)
+    end
+
+    def stage_ids
+      # Only list out processed/processing stages
+      Stage.where(:request_id => request_ids).where.not(:state => Stage::PENDING_STATE).pluck(:id)
+    end
+
+    def action_ids
+      Action.where(:stage_id => stage_ids).pluck(:id)
+    end
+
+    def workflow_ids
+      ids = SortedSet.new
+      @approver_acls.each do |acl|
+        acl.resource_definitions.any? do |rd|
+          next unless rd.attribute_filter.key == 'id'
+          next unless rd.attribute_filter.operation == 'equal'
+
+          ids << rd.attribute_filter.value.to_i
+        end
+      end
+      @workflow_ids = ids.to_a
+      Rails.logger.info("Workflows can be accessed: #{@workflow_ids}")
+      @workflow_ids
+    end
+  end
+end

--- a/lib/rbac/access.rb
+++ b/lib/rbac/access.rb
@@ -3,13 +3,9 @@ module RBAC
     include RBAC::Permissions
     attr_reader :acls, :approver_acls, :owner_acls
 
-    OWNER_PERMISSIONS = [ACTION_CREATE_PERMISSION, REQUEST_CREATE_PERMISSION,
-                         REQUEST_READ_PERMISSION, STAGE_READ_PERMISSION].freeze
-
     def initialize(resource, verb)
       @resource      = resource
       @verb          = verb
-      @regexp        = Regexp.new(":(#{@resource}|\\*):(#{@verb}|\\*)")
       @app_name      = ENV["APP_NAME"] || "approval"
       @admin         = false
       @approver      = false
@@ -22,27 +18,30 @@ module RBAC
     def process
       RBAC::Service.call(RBACApiClient::AccessApi) do |api|
         Rails.logger.info("Fetch access list for #{@app_name}")
-        @acls = RBAC::Service.paginate(api, :get_principal_access, {}, @app_name).select do |item|
-          Rails.logger.info("Found ACL: #{item}")
-          @regexp.match(item.permission)
-        end
+        full_acls = RBAC::Service.paginate(api, :get_principal_access, {}, @app_name)
 
-        @acls.any? do |item|
-          item.resource_definitions.any? do |rd|
-            @admin = true if rd.attribute_filter.key == 'id' &&
-                             rd.attribute_filter.operation == 'equal' &&
-                             rd.attribute_filter.value == '*'
-          end
-        end
-
+        regexp = Regexp.new(":(#{@resource}|\\*):(#{@verb}|\\*)")
         approver_regexp = Regexp.new(":(workflows|\\*):(approve|\\*)")
-        @approver_acls = RBAC::Service.paginate(api, :get_principal_access, {}, @app_name).select do |item|
-          approver_regexp.match(item.permission)
+
+        full_acls.each do |item|
+          Rails.logger.debug("Found ACL: #{item}")
+          @acls << item if regexp.match(item.permission)
+
+          unless @admin
+            item.resource_definitions.any? do |rd|
+              @admin = true if rd.attribute_filter.key == 'id' &&
+                               rd.attribute_filter.operation == 'equal' &&
+                               rd.attribute_filter.value == '*'
+            end
+          end
+
+          @approver_acls << item if approver_regexp.match(item.permission)
         end
+
         @approver = true if approver_acls.any?
 
         @owner_acls = requester_acls.select do |item|
-          @regexp.match(item.permission)
+          regexp.match(item.permission)
         end
 
         @owner = true if @owner_acls.any?
@@ -53,25 +52,45 @@ module RBAC
       self
     end
 
-    def id_list
-      case @resource
-      when "requests"
-        request_ids
-      when "stages"
-        stage_ids
-      when "actions"
-        action_ids
-      else
-        raise Exceptions::NotAuthorizedError, "Not Authorized for #{@resource}"
-      end
+    # resource ids approver can approve
+    def approver_id_list
+      id_list(approver_requests)
+    end
+
+    # resource ids owner owns
+    def owner_id_list
+      id_list(owner_requests)
+    end
+
+    # request ids that approver can approve
+    def approver_requests
+      @approver_requests ||= approver_request_ids
+    end
+
+    # request ids that owner owns
+    def owner_requests
+      @owner_requests ||= owner_request_ids
     end
 
     def self.enabled?
       ENV['BYPASS_RBAC'].blank?
     end
 
+    # permission level check
     def accessible?
-      @admin || @approver || @owner
+      @acls.any? || @owner_acls.any?
+    end
+
+    # approver but cannot approve the resource
+    def not_approvable?(resource_id)
+      resource_ids = approver_id_list
+      @approver && resource_ids && resource_ids.exclude?(resource_id)
+    end
+
+    # owner but does not own the resource
+    def not_owned?(resource_id)
+      resource_ids = owner_id_list
+      @owner && resource_ids && resource_ids.exclude?(resource_id)
     end
 
     def admin?
@@ -88,32 +107,51 @@ module RBAC
 
     private
 
-    def request_ids
+    def owner_request_ids
+      Request.by_owner.pluck(:id)
+    end
+
+    def approver_request_ids
       Request.where(:workflow_id => workflow_ids).pluck(:id)
     end
 
-    def stage_ids
-      # Only list out processed/processing stages
-      Stage.where(:request_id => request_ids).where.not(:state => Stage::PENDING_STATE).pluck(:id)
+    def id_list(request_ids)
+      case @resource
+      when "requests"
+        request_ids
+      when "stages"
+        stage_ids(request_ids)
+      when "actions"
+        action_ids(request_ids)
+      else
+        raise Exceptions::NotAuthorizedError, "Not Authorized for #{@resource}"
+      end
     end
 
-    def action_ids
-      Action.where(:stage_id => stage_ids).pluck(:id)
+    def stage_ids(request_ids)
+      Stage.where(:request_id => request_ids).pluck(:id)
+    end
+
+    def action_ids(request_ids)
+      Action.where(:stage_id => stage_ids(request_ids)).pluck(:id)
     end
 
     def workflow_ids
-      ids = SortedSet.new
-      @approver_acls.each do |acl|
-        acl.resource_definitions.any? do |rd|
-          next unless rd.attribute_filter.key == 'id'
-          next unless rd.attribute_filter.operation == 'equal'
+      @workflow_ids ||= begin
+        ids = SortedSet.new
+        @approver_acls.each do |acl|
+          acl.resource_definitions.any? do |rd|
+            next unless rd.attribute_filter.key == 'id'
+            next unless rd.attribute_filter.operation == 'equal'
 
-          ids << rd.attribute_filter.value.to_i
+            ids << rd.attribute_filter.value.to_i
+          end
         end
+
+        Rails.logger.info("Accessible workflows: #{ids}")
+
+        ids.to_a
       end
-      @workflow_ids = ids.to_a
-      Rails.logger.info("Workflows can be accessed: #{@workflow_ids}")
-      @workflow_ids
     end
 
     def requester_acls

--- a/lib/rbac/acls.rb
+++ b/lib/rbac/acls.rb
@@ -1,0 +1,70 @@
+module RBAC
+  class ACLS
+    def create(resource_id, permissions)
+      permissions.collect do |permission|
+        create_acl(permission, resource_id)
+      end
+    end
+
+    def remove(acls, resource_id, permissions)
+      permissions.each do |permission|
+        acls = delete_matching(acls, resource_id, permission)
+      end
+      acls
+    end
+
+    def add(acls, resource_id, permissions)
+      new_acls = []
+      permissions.each do |permission|
+        next if find_matching(acls, resource_id, permission)
+
+        new_acls << create_acl(permission, resource_id)
+      end
+      new_acls.empty? ? acls : new_acls + acls
+    end
+
+    def resource_defintions_empty?(acls, permission)
+      acls.each do |acl|
+        if acl.permission == permission
+          return acl.resource_definitions.empty?
+        end
+      end
+      true
+    end
+
+    private
+
+    def create_acl(permission, resource_id = nil)
+      resource_def = resource_definition(resource_id) if resource_id
+      RBACApiClient::Access.new.tap do |access|
+        access.permission = permission
+        access.resource_definitions = resource_def ? [resource_def] : []
+      end
+    end
+
+    def resource_definition(resource_id)
+      rdf = RBACApiClient::ResourceDefinitionFilter.new.tap do |obj|
+        obj.key       = 'id'
+        obj.operation = 'equal'
+        obj.value     = resource_id.to_s
+      end
+
+      RBACApiClient::ResourceDefinition.new.tap do |rd|
+        rd.attribute_filter = rdf
+      end
+    end
+
+    def matches?(access, resource_id, permission)
+      access.permission == permission &&
+        access.resource_definitions.any? { |rdf| rdf.attribute_filter.key == 'id' && rdf.attribute_filter.operation == 'equal' && rdf.attribute_filter.value == resource_id.to_s }
+    end
+
+    def find_matching(acls, resource_id, permission)
+      acls.detect { |access| matches?(access, resource_id, permission) }
+    end
+
+    def delete_matching(acls, resource_id, permission)
+      acls.delete_if { |access| matches?(access, resource_id, permission) }
+    end
+  end
+end

--- a/lib/rbac/acls.rb
+++ b/lib/rbac/acls.rb
@@ -7,18 +7,16 @@ module RBAC
     end
 
     def remove(acls, resource_id, permissions)
-      permissions.each do |permission|
-        acls = delete_matching(acls, resource_id, permission)
+      permissions.each_with_object(acls) do |permission, as|
+        delete_matching(as, resource_id, permission)
       end
-      acls
     end
 
     def add(acls, resource_id, permissions)
-      new_acls = []
-      permissions.each do |permission|
+      new_acls = permissions.each_with_object([]) do |permission, as|
         next if find_matching(acls, resource_id, permission)
 
-        new_acls << create_acl(permission, resource_id)
+        as << create_acl(permission, resource_id)
       end
       new_acls.empty? ? acls : new_acls + acls
     end

--- a/lib/rbac/permissions.rb
+++ b/lib/rbac/permissions.rb
@@ -1,0 +1,8 @@
+module RBAC
+  module Permissions
+    ACTION_CREATE_PERMISSION  = 'approval:actions:create'.freeze
+    REQUEST_CREATE_PERMISSION = 'approval:requests:create'.freeze
+    REQUEST_READ_PERMISSION   = 'approval:requests:read'.freeze
+    STAGE_READ_PERMISSION     = 'approval:stages:read'.freeze
+  end
+end

--- a/lib/rbac/permissions.rb
+++ b/lib/rbac/permissions.rb
@@ -1,8 +1,16 @@
 module RBAC
   module Permissions
-    ACTION_CREATE_PERMISSION  = 'approval:actions:create'.freeze
-    REQUEST_CREATE_PERMISSION = 'approval:requests:create'.freeze
-    REQUEST_READ_PERMISSION   = 'approval:requests:read'.freeze
-    STAGE_READ_PERMISSION     = 'approval:stages:read'.freeze
+    ACTION_CREATE_PERMISSION    = 'approval:actions:create'.freeze
+    ACTION_READ_PERMISSION      = 'approval:actions:read'.freeze
+    REQUEST_CREATE_PERMISSION   = 'approval:requests:create'.freeze
+    REQUEST_READ_PERMISSION     = 'approval:requests:read'.freeze
+    STAGE_READ_PERMISSION       = 'approval:stages:read'.freeze
+    WORKFLOW_APPROVE_PERMISSION = 'approval:workflows:approve'.freeze
+
+    APPROVER_PERMISSIONS = [ACTION_CREATE_PERMISSION, ACTION_READ_PERMISSION,
+                            REQUEST_READ_PERMISSION, STAGE_READ_PERMISSION].freeze
+
+    OWNER_PERMISSIONS = [ACTION_CREATE_PERMISSION, REQUEST_CREATE_PERMISSION,
+                         REQUEST_READ_PERMISSION, STAGE_READ_PERMISSION].freeze
   end
 end

--- a/lib/rbac/roles.rb
+++ b/lib/rbac/roles.rb
@@ -3,7 +3,6 @@ module RBAC
     def initialize(prefix)
       @roles = {}
       load(prefix)
-      @deleted_roles = SortedSet.new
     end
 
     def find(name)
@@ -33,7 +32,6 @@ module RBAC
     end
 
     def delete(role)
-      @deleted_roles.add(role.uuid)
       RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
         api_instance.delete_role(role.uuid)
       end
@@ -52,8 +50,6 @@ module RBAC
     end
 
     def get(uuid)
-      raise ArgumentError, "Role object #{uuid} has been deleted" if @deleted_roles.include?(uuid)
-
       RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
         api_instance.get_role(uuid)
       end

--- a/lib/rbac/roles.rb
+++ b/lib/rbac/roles.rb
@@ -1,0 +1,62 @@
+module RBAC
+  class Roles
+    def initialize(prefix)
+      @roles = {}
+      load(prefix)
+      @deleted_roles = SortedSet.new
+    end
+
+    def find(name)
+      uuid = @roles[name]
+      get(uuid) if uuid
+    end
+
+    def with_each_role
+      @roles.each_value do |uuid|
+        yield get(uuid)
+      end
+    end
+
+    def add(name, acls)
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+        role_in = RBACApiClient::RoleIn.new
+        role_in.name = name
+        role_in.access = acls
+        api_instance.create_roles(role_in)
+      end
+    end
+
+    def update(role)
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+        api_instance.update_role(role.uuid, role)
+      end
+    end
+
+    def delete(role)
+      @deleted_roles.add(role.uuid)
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+        api_instance.delete_role(role.uuid)
+      end
+    end
+
+    private
+
+    def load(prefix)
+      opts = { :limit => 100,
+               :name  => prefix }
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+        RBAC::Service.paginate(api_instance, :list_roles, opts).each do |role|
+          @roles[role.name] = role.uuid
+        end
+      end
+    end
+
+    def get(uuid)
+      raise ArgumentError, "Role object #{uuid} has been deleted" if @deleted_roles.include?(uuid)
+
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+        api_instance.get_role(uuid)
+      end
+    end
+  end
+end

--- a/spec/lib/rbac/access_spec.rb
+++ b/spec/lib/rbac/access_spec.rb
@@ -1,0 +1,135 @@
+describe RBAC::Access do
+  include_context "rbac_objects"
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi).and_yield(api_instance)
+  end
+
+  shared_examples_for "#rbac_role?" do
+    it "validate role" do
+      with_modified_env :APP_NAME => app_name do
+        allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return(acls)
+        svc_obj = rbac_access.process
+        expect(svc_obj.acls.count).to eq(acl_count)
+        expect(svc_obj.approver_acls.count).to eq(approver_acl_count)
+        expect(svc_obj.owner?).to eq(owner_result)
+        expect(svc_obj.admin?).to eq(admin_result)
+        expect(svc_obj.approver?).to eq(approver_result)
+      end
+    end
+  end
+
+  shared_examples_for "#id_list?" do
+    it "id list" do
+      with_modified_env :APP_NAME => app_name do
+        allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return(acls)
+        svc_obj = rbac_access.process
+        expect(svc_obj.approver?).to be_truthy 
+        expect(svc_obj.id_list).to eq(resource_id_list)
+      end
+    end
+  end
+
+  context "owner access" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [owner_access] }
+    let(:owner_result) { true }
+    let(:admin_result) { false }
+    let(:approver_result) { false }
+    let(:acl_count) { 1 }
+    let(:approver_acl_count) { 0 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "owner access and admin access" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [admin_access, owner_access] }
+    let(:admin_result) { true }
+    let(:owner_result) { false }
+    let(:approver_result) { false }
+    let(:acl_count) { 2 }
+    let(:approver_acl_count) { 0 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "fetches the array of plans" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [access1] }
+    let(:admin_result) { false }
+    let(:owner_result) { false }
+    let(:approver_result) { false }
+    let(:acl_count) { 1 }
+    let(:approver_acl_count) { 0 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "approver access" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [approver_access] }
+    let(:admin_result) { false }
+    let(:owner_result) { false }
+    let(:approver_result) { true }
+    let(:acl_count) { 0 }
+    let(:approver_acl_count) { 1 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "id_list" do
+    let!(:workflows) { create_list(:workflow, 2) }
+    let!(:request1) { create(:request, :workflow_id => workflows.first.id) }
+    let!(:request2) { create(:request, :workflow_id => workflows.last.id) }
+    let!(:stages1) { create_list(:stage, 2, :state => 'notified', :request_id => request1.id) }
+    let!(:stage2) { create(:stage, :state => 'pending', :request_id => request1.id) }
+    let!(:stage3) { create(:stage, :state => 'notified', :request_id => request2.id) }
+    let!(:actions1) { create_list(:action, 2, :stage_id => stages1.first.id) }
+    let!(:actions2) { create_list(:action, 3, :stage_id => stages1.last.id) }
+
+    let(:approver_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => workflows.first.id) }
+    let(:approver_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => approver_filter) }
+    let(:approver_access) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:workflows:approve", :resource_definitions => [approver_resource_def]) }
+
+    describe "id list for request" do
+      let(:rbac_access) { described_class.new('requests', 'read') }
+
+      context "when is approver" do
+        let(:acls) { [approver_access] }
+        let(:resource_id_list) { [request1.id] }
+        it_behaves_like "#id_list?"
+      end
+    end
+
+    describe "id list for stage" do
+      let(:rbac_access) { described_class.new('stages', 'read') }
+
+      context "id list for approver" do
+        let(:acls) { [approver_access] }
+        let(:resource_id_list) { stages1.pluck(:id) }
+        it_behaves_like "#id_list?"
+      end
+    end
+
+    describe "id list for action" do
+      let(:rbac_access) { described_class.new('actions', 'read') }
+
+      context "id list for approver" do
+        let(:acls) { [approver_access] }
+        let(:resource_id_list) { Action.all.pluck(:id) }
+        it_behaves_like "#id_list?"
+      end
+    end
+  end
+
+  it "rbac is enabled by default" do
+    expect(described_class.enabled?).to be_truthy
+  end
+
+  it "rbac is enabled by default" do
+    with_modified_env :BYPASS_RBAC => "1" do
+      expect(described_class.enabled?).to be_falsey
+    end
+  end
+end

--- a/spec/lib/rbac/access_spec.rb
+++ b/spec/lib/rbac/access_spec.rb
@@ -9,12 +9,14 @@ describe RBAC::Access do
     it "validate role" do
       with_modified_env :APP_NAME => app_name do
         allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return(acls)
+        allow(Request).to receive(:by_owner).and_return([])
         svc_obj = rbac_access.process
         expect(svc_obj.acls.count).to eq(acl_count)
         expect(svc_obj.approver_acls.count).to eq(approver_acl_count)
-        expect(svc_obj.owner?).to eq(owner_result)
-        expect(svc_obj.admin?).to eq(admin_result)
-        expect(svc_obj.approver?).to eq(approver_result)
+        expect(svc_obj.owner_acls.count).to eq(owner_acl_count)
+        expect(svc_obj.owner?).to eq(owner_flag)
+        expect(svc_obj.admin?).to eq(admin_flag)
+        expect(svc_obj.approver?).to eq(approver_flag)
       end
     end
   end
@@ -23,9 +25,10 @@ describe RBAC::Access do
     it "id list" do
       with_modified_env :APP_NAME => app_name do
         allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return(acls)
+        allow(Request).to receive(:by_owner).and_return([])
         svc_obj = rbac_access.process
         expect(svc_obj.approver?).to be_truthy
-        expect(svc_obj.id_list).to eq(resource_id_list)
+        expect(svc_obj.approver_id_list).to eq(resource_id_list)
       end
     end
   end
@@ -34,10 +37,11 @@ describe RBAC::Access do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
     let(:acls) { [admin_access, access1] }
-    let(:owner_result) { true }
-    let(:admin_result) { true }
-    let(:approver_result) { false }
+    let(:owner_flag) { true }
+    let(:admin_flag) { true }
+    let(:approver_flag) { false }
     let(:acl_count) { 2 }
+    let(:owner_acl_count) { 1 }
     let(:approver_acl_count) { 0 }
     it_behaves_like "#rbac_role?"
   end
@@ -46,10 +50,11 @@ describe RBAC::Access do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
     let(:acls) { [access1] }
-    let(:owner_result) { true }
-    let(:admin_result) { false }
-    let(:approver_result) { false }
+    let(:owner_flag) { true }
+    let(:admin_flag) { false }
+    let(:approver_flag) { false }
     let(:acl_count) { 1 }
+    let(:owner_acl_count) { 1 }
     let(:approver_acl_count) { 0 }
     it_behaves_like "#rbac_role?"
   end
@@ -58,10 +63,11 @@ describe RBAC::Access do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
     let(:acls) { [approver_access] }
-    let(:owner_result) { true }
-    let(:admin_result) { false }
-    let(:approver_result) { true }
+    let(:owner_flag) { true }
+    let(:admin_flag) { false }
+    let(:approver_flag) { true }
     let(:acl_count) { 0 }
+    let(:owner_acl_count) { 1 }
     let(:approver_acl_count) { 1 }
     it_behaves_like "#rbac_role?"
   end
@@ -70,10 +76,11 @@ describe RBAC::Access do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
     let(:acls) { [approver_access, admin_access] }
-    let(:owner_result) { true }
-    let(:admin_result) { true }
-    let(:approver_result) { true }
+    let(:owner_flag) { true }
+    let(:admin_flag) { true }
+    let(:approver_flag) { true }
     let(:acl_count) { 1 }
+    let(:owner_acl_count) { 1 }
     let(:approver_acl_count) { 1 }
     it_behaves_like "#rbac_role?"
   end
@@ -82,10 +89,11 @@ describe RBAC::Access do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
     let(:acls) { [approver_access, admin_access] }
-    let(:owner_result) { true }
-    let(:admin_result) { true }
-    let(:approver_result) { true }
+    let(:owner_flag) { true }
+    let(:admin_flag) { true }
+    let(:approver_flag) { true }
     let(:acl_count) { 1 }
+    let(:owner_acl_count) { 1 }
     let(:approver_acl_count) { 1 }
     it_behaves_like "#rbac_role?"
   end
@@ -95,8 +103,7 @@ describe RBAC::Access do
     let!(:request1) { create(:request, :workflow_id => workflows.first.id) }
     let!(:request2) { create(:request, :workflow_id => workflows.last.id) }
     let!(:stages1) { create_list(:stage, 2, :state => 'notified', :request_id => request1.id) }
-    let!(:stage2) { create(:stage, :state => 'pending', :request_id => request1.id) }
-    let!(:stage3) { create(:stage, :state => 'notified', :request_id => request2.id) }
+    let!(:stage2) { create(:stage, :state => 'notified', :request_id => request2.id) }
     let!(:actions1) { create_list(:action, 2, :stage_id => stages1.first.id) }
     let!(:actions2) { create_list(:action, 3, :stage_id => stages1.last.id) }
 
@@ -104,34 +111,28 @@ describe RBAC::Access do
     let(:approver_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => approver_filter) }
     let(:approver_access) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:workflows:approve", :resource_definitions => [approver_resource_def]) }
 
-    describe "id list for request" do
+    describe "for requests" do
       let(:rbac_access) { described_class.new('requests', 'read') }
+      let(:acls) { [approver_access] }
+      let(:resource_id_list) { [request1.id] }
 
-      context "when is approver" do
-        let(:acls) { [approver_access] }
-        let(:resource_id_list) { [request1.id] }
-        it_behaves_like "#id_list?"
-      end
+      it_behaves_like "#id_list?"
     end
 
-    describe "id list for stage" do
+    describe "for stages" do
       let(:rbac_access) { described_class.new('stages', 'read') }
+      let(:acls) { [approver_access] }
+      let(:resource_id_list) { stages1.pluck(:id) }
 
-      context "id list for approver" do
-        let(:acls) { [approver_access] }
-        let(:resource_id_list) { stages1.pluck(:id) }
-        it_behaves_like "#id_list?"
-      end
+      it_behaves_like "#id_list?"
     end
 
     describe "id list for action" do
       let(:rbac_access) { described_class.new('actions', 'read') }
+      let(:acls) { [approver_access] }
+      let(:resource_id_list) { Action.all.pluck(:id) }
 
-      context "id list for approver" do
-        let(:acls) { [approver_access] }
-        let(:resource_id_list) { Action.all.pluck(:id) }
-        it_behaves_like "#id_list?"
-      end
+      it_behaves_like "#id_list?"
     end
   end
 

--- a/spec/lib/rbac/access_spec.rb
+++ b/spec/lib/rbac/access_spec.rb
@@ -24,16 +24,28 @@ describe RBAC::Access do
       with_modified_env :APP_NAME => app_name do
         allow(RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, {}, app_name).and_return(acls)
         svc_obj = rbac_access.process
-        expect(svc_obj.approver?).to be_truthy 
+        expect(svc_obj.approver?).to be_truthy
         expect(svc_obj.id_list).to eq(resource_id_list)
       end
     end
   end
 
-  context "owner access" do
+  context "when have admin access" do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
-    let(:acls) { [owner_access] }
+    let(:acls) { [admin_access, access1] }
+    let(:owner_result) { true }
+    let(:admin_result) { true }
+    let(:approver_result) { false }
+    let(:acl_count) { 2 }
+    let(:approver_acl_count) { 0 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "when have no admin access" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [access1] }
     let(:owner_result) { true }
     let(:admin_result) { false }
     let(:approver_result) { false }
@@ -42,38 +54,38 @@ describe RBAC::Access do
     it_behaves_like "#rbac_role?"
   end
 
-  context "owner access and admin access" do
-    let(:verb) { "read" }
-    let(:rbac_access) { described_class.new(resource, verb) }
-    let(:acls) { [admin_access, owner_access] }
-    let(:admin_result) { true }
-    let(:owner_result) { false }
-    let(:approver_result) { false }
-    let(:acl_count) { 2 }
-    let(:approver_acl_count) { 0 }
-    it_behaves_like "#rbac_role?"
-  end
-
-  context "fetches the array of plans" do
-    let(:verb) { "read" }
-    let(:rbac_access) { described_class.new(resource, verb) }
-    let(:acls) { [access1] }
-    let(:admin_result) { false }
-    let(:owner_result) { false }
-    let(:approver_result) { false }
-    let(:acl_count) { 1 }
-    let(:approver_acl_count) { 0 }
-    it_behaves_like "#rbac_role?"
-  end
-
-  context "approver access" do
+  context "when have approver access" do
     let(:verb) { "read" }
     let(:rbac_access) { described_class.new(resource, verb) }
     let(:acls) { [approver_access] }
+    let(:owner_result) { true }
     let(:admin_result) { false }
-    let(:owner_result) { false }
     let(:approver_result) { true }
     let(:acl_count) { 0 }
+    let(:approver_acl_count) { 1 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "when have both admin and approver access" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [approver_access, admin_access] }
+    let(:owner_result) { true }
+    let(:admin_result) { true }
+    let(:approver_result) { true }
+    let(:acl_count) { 1 }
+    let(:approver_acl_count) { 1 }
+    it_behaves_like "#rbac_role?"
+  end
+
+  context "when have both admin and approver access" do
+    let(:verb) { "read" }
+    let(:rbac_access) { described_class.new(resource, verb) }
+    let(:acls) { [approver_access, admin_access] }
+    let(:owner_result) { true }
+    let(:admin_result) { true }
+    let(:approver_result) { true }
+    let(:acl_count) { 1 }
     let(:approver_acl_count) { 1 }
     it_behaves_like "#rbac_role?"
   end

--- a/spec/lib/rbac/acls_spec.rb
+++ b/spec/lib/rbac/acls_spec.rb
@@ -1,0 +1,105 @@
+describe RBAC::ACLS do
+  let (:subject) { described_class.new }
+  let (:permissions) { ['approval:actions:read', 'approval:actions:create'] }
+  let (:resource_id) { "10" }
+
+  context "when create acls based on permissions" do
+
+    it "with resource id" do
+      acls = subject.create(resource_id, permissions)
+
+      expect(acls.count).to eq(2)
+      expect(acls.first.permission).to eq(permissions.first)
+      expect(acls.last.permission).to eq(permissions.last)
+      expect(acls.last.resource_definitions.count).to eq(1)
+      expect(acls.last.resource_definitions.first.attribute_filter.key).to eq("id")
+      expect(acls.last.resource_definitions.first.attribute_filter.operation).to eq("equal")
+      expect(acls.last.resource_definitions.first.attribute_filter.value).to eq(resource_id)
+    end
+
+    it "without resource id" do
+      acls = subject.create(nil, permissions)
+
+      expect(acls.count).to eq(2)
+      expect(acls.first.permission).to eq(permissions.first)
+      expect(acls.last.permission).to eq(permissions.last)
+      expect(acls.last.resource_definitions).to eq([]) 
+    end
+  end
+
+  context "when remove acls" do
+    let(:acls) { subject.create(resource_id, permissions) }
+    let(:existing_permissions) { [permissions.first] }
+    let(:not_existing_permissions) { ['approval:requests:read'] }
+    let(:mix_existing_permissions) { [permissions.last, 'approval:requests:read'] }
+
+    it "with matching permissions" do
+      new_acls = subject.remove(acls, resource_id, existing_permissions)
+
+      expect(new_acls.count).to eq(1)
+      expect(new_acls.first.permission).to eq(permissions.last)
+      expect(new_acls.first.resource_definitions.count).to eq(1)
+    end
+
+    it "with non-matching permissions" do
+      new_acls = subject.remove(acls, resource_id, not_existing_permissions)
+
+      expect(new_acls.count).to eq(2)
+      expect(new_acls.first.permission).to eq(permissions.first)
+      expect(new_acls.last.permission).to eq(permissions.last)
+      expect(new_acls.first.resource_definitions.count).to eq(1)
+    end
+  
+    it "with mixed matching permissions" do
+      new_acls = subject.remove(acls, resource_id, mix_existing_permissions)
+
+      expect(new_acls.count).to eq(1)
+      expect(new_acls.first.permission).to eq(permissions.first)
+      expect(new_acls.first.resource_definitions.count).to eq(1)
+    end
+  end
+
+  context "when add acls" do
+    let(:acls) { subject.create(resource_id, permissions) }
+    let(:existing_permissions) { [permissions.first] }
+    let(:not_existing_permissions) { ['approval:requests:read'] }
+    let(:mix_existing_permissions) { [permissions.last, 'approval:requests:read'] }
+
+    it "with matching permissions" do
+      new_acls = subject.add(acls, resource_id, existing_permissions)
+
+      expect(new_acls.count).to eq(2)
+      expect(new_acls.first.permission).to eq(permissions.first)
+      expect(new_acls.first.resource_definitions.count).to eq(1)
+    end
+
+    it "with non-matching permissions" do
+      new_acls = subject.add(acls, resource_id, not_existing_permissions)
+
+      expect(new_acls.count).to eq(3)
+      expect(new_acls.first.permission).to eq('approval:requests:read')
+      expect(new_acls.first.resource_definitions.count).to eq(1)
+    end
+
+    it "with mix matching permissions" do
+      new_acls = subject.add(acls, resource_id, mix_existing_permissions)
+
+      expect(new_acls.count).to eq(3)
+      expect(new_acls.first.permission).to eq('approval:requests:read')
+      expect(new_acls.last.permission).to eq(permissions.last)
+    end
+  end
+
+  context "check resource definitions" do
+    let(:acls_with_ids) { subject.create(resource_id, permissions) }
+    let(:acls_no_ids)   { subject.create(nil, permissions) }
+
+    it "empty?" do
+      with_ids = subject.resource_defintions_empty?(acls_with_ids, permissions.first)
+      no_ids   = subject.resource_defintions_empty?(acls_no_ids, permissions.first)
+
+      expect(with_ids).to be_falsey
+      expect(no_ids).to be_truthy
+    end
+  end
+end

--- a/spec/lib/rbac/acls_spec.rb
+++ b/spec/lib/rbac/acls_spec.rb
@@ -1,10 +1,9 @@
 describe RBAC::ACLS do
-  let (:subject) { described_class.new }
-  let (:permissions) { ['approval:actions:read', 'approval:actions:create'] }
-  let (:resource_id) { "10" }
+  let(:subject) { described_class.new }
+  let(:permissions) { ['approval:actions:read', 'approval:actions:create'] }
+  let(:resource_id) { "10" }
 
   context "when create acls based on permissions" do
-
     it "with resource id" do
       acls = subject.create(resource_id, permissions)
 
@@ -23,7 +22,7 @@ describe RBAC::ACLS do
       expect(acls.count).to eq(2)
       expect(acls.first.permission).to eq(permissions.first)
       expect(acls.last.permission).to eq(permissions.last)
-      expect(acls.last.resource_definitions).to eq([]) 
+      expect(acls.last.resource_definitions).to eq([])
     end
   end
 
@@ -49,7 +48,7 @@ describe RBAC::ACLS do
       expect(new_acls.last.permission).to eq(permissions.last)
       expect(new_acls.first.resource_definitions.count).to eq(1)
     end
-  
+
     it "with mixed matching permissions" do
       new_acls = subject.remove(acls, resource_id, mix_existing_permissions)
 

--- a/spec/lib/rbac/roles_spec.rb
+++ b/spec/lib/rbac/roles_spec.rb
@@ -1,0 +1,53 @@
+describe RBAC::Roles do
+  let(:prefix) { "approval-group-" }
+  let(:subject) { described_class.new(prefix) }
+  let(:api_instance) { double }
+  let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:pagination_options) { { :limit => 100, :name => prefix } }
+
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:group2) { instance_double(RBACApiClient::GroupOut, :name => 'group2', :uuid => "12345") }
+  let(:group3) { instance_double(RBACApiClient::GroupOut, :name => 'group3', :uuid => "45665") }
+  let(:groups) { [group1, group2, group3] }
+  let(:role1) { instance_double(RBACApiClient::RoleOut, :name => "approval-group-#{group1.uuid}", :uuid => "67899") }
+  let(:role1_detail) { instance_double(RBACApiClient::RoleWithAccess, :name => role1.name, :uuid => role1.uuid) }
+  let(:role2) { instance_double(RBACApiClient::RoleOut, :name => "approval-group-#{group2.uuid}", :uuid => "55555") }
+  let(:roles) { {role1.name => role1.uuid, role2.name => role2.uuid} }
+  let(:access1) { instance_double(RBACApiClient::Access, :permission => "approval:actions:read", :resource_definitions => []) }
+  let(:acls) { [access1] }
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi).and_yield(api_instance)
+    allow(rs_class).to receive(:call).with(RBACApiClient::RoleApi).and_yield(api_instance)
+  end
+
+  it "check roles" do
+    allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1, role2])
+
+    expect(subject.instance_variable_get(:@roles).count).to eq(roles.count)
+    expect(subject.instance_variable_get(:@roles)[role1.name]).to eq(role1.uuid)
+    expect(subject.instance_variable_get(:@roles)[role2.name]).to eq(role2.uuid)
+  end
+
+  it "find roles" do
+    allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1, role2])
+    allow(api_instance).to receive(:get_role).with(role1.uuid).and_return(role1_detail)
+    allow(api_instance).to receive(:get_role).with(role2.uuid).and_return(nil)
+
+    r1 = subject.find(role1.name)
+    expect(r1.name).to eq(role1.name)
+    expect(r1.uuid).to eq(role1.uuid)
+
+    r2 = subject.find(role2.name)
+    expect(r2).to be_nil
+  end
+
+
+  it "add roles" do
+    allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1, role2])
+    allow(api_instance).to receive(:create_roles).and_return(role1_detail)
+
+    r = subject.add(role1.name, acls)
+    expect(r.name).to eq(role1.name)
+  end
+end

--- a/spec/lib/rbac/roles_spec.rb
+++ b/spec/lib/rbac/roles_spec.rb
@@ -42,7 +42,6 @@ describe RBAC::Roles do
     expect(r2).to be_nil
   end
 
-
   it "add roles" do
     allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1, role2])
     allow(api_instance).to receive(:create_roles).and_return(role1_detail)

--- a/spec/support/rbac_shared_contexts.rb
+++ b/spec/support/rbac_shared_contexts.rb
@@ -1,0 +1,43 @@
+RSpec.shared_context "rbac_objects" do
+  let(:app_name) { 'approval' }
+  let(:resource) { "requests" }
+  let(:resource_id1) { "1" }
+  let(:resource_id2) { "2" }
+  let(:resource_id3) { "3" }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:group2) { instance_double(RBACApiClient::GroupOut, :name => 'group2', :uuid => "12345") }
+  let(:group3) { instance_double(RBACApiClient::GroupOut, :name => 'group3', :uuid => "45665") }
+  let(:role1) { instance_double(RBACApiClient::RoleOut, :name => "#{app_name}-#{resource}-#{resource_id1}-group-#{group1.uuid}", :uuid => "67899") }
+  let(:role2) { instance_double(RBACApiClient::RoleOut, :name => "#{app_name}-#{resource}-#{resource_id2}-group-#{group1.uuid}", :uuid => "55555") }
+  let(:groups) { [group1, group2, group3] }
+  let(:roles) { [role1] }
+  let(:policies) { [instance_double(RBACApiClient::PolicyIn, :group => group1, :roles => roles)] }
+  let(:filter1) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => resource_id1) }
+  let(:resource_def1) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => filter1) }
+  let(:filter2) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => resource_id2) }
+  let(:resource_def2) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => filter2) }
+  let(:filter3) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => resource_id3) }
+  let(:resource_def3) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => filter3) }
+  let(:access1) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:read", :resource_definitions => [resource_def1]) }
+  let(:access2) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:write", :resource_definitions => [resource_def2]) }
+  let(:access3) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:order", :resource_definitions => []) }
+  let(:group_uuids) { [group1.uuid, group2.uuid, group3.uuid] }
+  let(:api_instance) { double }
+  let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+
+  let(:approver_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => resource_id1) }
+  let(:approver_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => approver_filter) }
+  let(:approver_access) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:workflows:approve", :resource_definitions => [approver_resource_def]) }
+
+  let(:current_user) { '{{username}}' }
+  let(:owner_resource) { 'requests' }
+  let(:owner_permission) { "#{app_name}:#{owner_resource}:read" }
+  let(:owner_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'owner', :operation => 'equal', :value => current_user) }
+  let(:owner_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => owner_filter) }
+  let(:owner_access) { instance_double(RBACApiClient::Access, :permission => owner_permission, :resource_definitions => [owner_resource_def]) }
+
+  let(:id_value) { '*' }
+  let(:id_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => id_value) }
+  let(:id_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => id_filter) }
+  let(:admin_access) { instance_double(RBACApiClient::Access, :permission => owner_permission, :resource_definitions => [id_resource_def]) }
+end

--- a/spec/support/rbac_shared_contexts.rb
+++ b/spec/support/rbac_shared_contexts.rb
@@ -20,7 +20,8 @@ RSpec.shared_context "rbac_objects" do
   let(:resource_def3) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => filter3) }
   let(:access1) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:read", :resource_definitions => [resource_def1]) }
   let(:access2) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:write", :resource_definitions => [resource_def2]) }
-  let(:access3) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:order", :resource_definitions => []) }
+  let(:access3) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:create", :resource_definitions => []) }
+  let(:access4) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:create") }
   let(:group_uuids) { [group1.uuid, group2.uuid, group3.uuid] }
   let(:api_instance) { double }
   let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
@@ -29,15 +30,8 @@ RSpec.shared_context "rbac_objects" do
   let(:approver_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => approver_filter) }
   let(:approver_access) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:workflows:approve", :resource_definitions => [approver_resource_def]) }
 
-  let(:current_user) { '{{username}}' }
-  let(:owner_resource) { 'requests' }
-  let(:owner_permission) { "#{app_name}:#{owner_resource}:read" }
-  let(:owner_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'owner', :operation => 'equal', :value => current_user) }
-  let(:owner_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => owner_filter) }
-  let(:owner_access) { instance_double(RBACApiClient::Access, :permission => owner_permission, :resource_definitions => [owner_resource_def]) }
-
   let(:id_value) { '*' }
   let(:id_filter) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => id_value) }
   let(:id_resource_def) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => id_filter) }
-  let(:admin_access) { instance_double(RBACApiClient::Access, :permission => owner_permission, :resource_definitions => [id_resource_def]) }
+  let(:admin_access) { instance_double(RBACApiClient::Access, :permission => 'approval:requests:read', :resource_definitions => [id_resource_def]) }
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -72,10 +72,6 @@ module RequestSpecHelper
     {:headers => default_headers, :original_url => 'https://xyz.com/api/requests'}
   end
 
-  def bypass_rbac
-    with_modified_env(:BYPASS_RBAC => 'true') { yield }
-  end
-
   def with_modified_env(options, &block)
     ClimateControl.modify(options, &block)
   end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -71,4 +71,12 @@ module RequestSpecHelper
   def default_request_hash
     {:headers => default_headers, :original_url => 'https://xyz.com/api/requests'}
   end
+
+  def bypass_rbac
+    with_modified_env(:BYPASS_RBAC => 'true') { yield }
+  end
+
+  def with_modified_env(options, &block)
+    ClimateControl.modify(options, &block)
+  end
 end


### PR DESCRIPTION
This is the second phase to enable RBAC support in Approval service:

1. create `RBAC::Access` to handle access control list (acls) based on predefined permissions and resource definitions;
2. set role (`admin, approver, owner`) according to acls;

