### PR TITLE
Predefined RBAC roles/acls/policies/groups

### DIFF
--- a/data/rbac_approval_seed.yml
+++ b/data/rbac_approval_seed.yml
@@ -4,11 +4,6 @@ resource_definition1: &AdminResourceDefinition
     value: '*'
     key: id
     operation: equal
-resource_definition2: &OwnerResourceDefinition
-  attributeFilter: 
-    value: '{{username}}'
-    key: owner
-    operation: equal
 access1: &AdminReadAccessTemplates
   permission: approval:templates:read
   resourceDefinitions:
@@ -41,12 +36,6 @@ access8: &AdminCreateAccessActions
   permission: approval:actions:create
   resourceDefinitions:
           - *AdminResourceDefinition
-access51: &RequesterCreateAccessRequests
-  permission: approval:requests:create
-access52: &RequesterReadAccessRequests
-  permission: approval:requests:read
-  resourceDefinitions:
-          - *OwnerResourceDefinition
 access61: &ApproverCreateAccessActions
   permission: approval:actions:create
 access62: &ApproverReadAccessActions
@@ -69,15 +58,7 @@ role1: &ApprovalAdministratorRole
     - *AdminReadAccessStages
     - *AdminReadAccessActions
     - *AdminCreateAccessActions
-role2: &ApprovalRequesterRole
-  name: Approval Requester
-  system: true
-  version: 3
-  description: An Approval requester roles grants read and create permissions
-  access:
-    - *RequesterCreateAccessRequests
-    - *RequesterReadAccessRequests
-role3: &ApprovalApproverRole
+role2: &ApprovalApproverRole
   name: Approval Approver
   system: true
   version: 3
@@ -90,26 +71,15 @@ role3: &ApprovalApproverRole
 group1: &ApprovalAdministratorsGroup
   name: Approval Administrators
   description: Approval Administrators have complete access to all objects in the Approval Service.
-group2: &ApprovalRequestersGroup
-  name: Approval Requesters
-  description: Approval Requesters have limited access to certain objects in the Approval Service.
 policy1: &ApprovalAdministratorPolicy
   name: Approval Administrator
   group: *ApprovalAdministratorsGroup
   role: *ApprovalAdministratorRole
   description: Policy for Approval Administrators who have complete access to all objects in the Approval Service.
-policy2: &ApprovalRequesterPolicy
-  name: Approval Requester
-  group: *ApprovalRequestersGroup
-  role: *ApprovalRequesterRole
-  description: Policy for Approval Requesters who can limit access to certain objects in the Approval Service
 roles:
   - *ApprovalAdministratorRole
-  - *ApprovalRequesterRole
   - *ApprovalApproverRole
 groups:
   - *ApprovalAdministratorsGroup
-  - *ApprovalRequestersGroup
 policies:
   - *ApprovalAdministratorPolicy
-  - *ApprovalRequesterPolicy

--- a/data/rbac_approval_seed.yml
+++ b/data/rbac_approval_seed.yml
@@ -51,7 +51,7 @@ access64: &ApproverReadAccessRequests
 role1: &ApprovalAdministratorRole
   name: Approval Administrator
   system: true
-  version: 1
+  version: 2
   description: An Approval administrator role that grants create, read, update and destroy permissions
   access:
     - *AdminReadAccessTemplates
@@ -66,7 +66,7 @@ role1: &ApprovalAdministratorRole
 role2: &ApprovalApproverRole
   name: Approval Approver
   system: true
-  version: 1
+  version: 2
   description: An Approval approver role that grants read and create permissions
   access:
     - *ApproverReadAccessRequests

--- a/data/rbac_approval_seed.yml
+++ b/data/rbac_approval_seed.yml
@@ -1,0 +1,115 @@
+---
+resource_definition1: &AdminResourceDefinition
+  attributeFilter: 
+    value: '*'
+    key: id
+    operation: equal
+resource_definition2: &OwnerResourceDefinition
+  attributeFilter: 
+    value: '{{username}}'
+    key: owner
+    operation: equal
+access1: &AdminReadAccessTemplates
+  permission: approval:templates:read
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access2: &AdminCreateAccessWorkflows
+  permission: approval:workflows:create
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access3: &AdminReadAccessWorkflows
+  permission: approval:workflows:read
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access4: &AdminUpdateAccessWorkflows
+  permission: approval:workflows:update
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access5: &AdminReadAccessRequests
+  permission: approval:requests:read
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access6: &AdminReadAccessStages
+  permission: approval:stages:read
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access7: &AdminReadAccessActions
+  permission: approval:actions:read
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access8: &AdminCreateAccessActions
+  permission: approval:actions:create
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access51: &RequesterCreateAccessRequests
+  permission: approval:requests:create
+access52: &RequesterReadAccessRequests
+  permission: approval:requests:read
+  resourceDefinitions:
+          - *OwnerResourceDefinition
+access61: &ApproverCreateAccessActions
+  permission: approval:actions:create
+access62: &ApproverReadAccessActions
+  permission: approval:actions:read
+access63: &ApproverReadAccessStages
+  permission: approval:stages:read
+access64: &ApproverReadAccessRequests
+  permission: approval:requests:read
+role1: &ApprovalAdministratorRole
+  name: Approval Administrator
+  system: true
+  version: 3
+  description: An Approval administrator roles grants create, read and update permissions
+  access:
+    - *AdminReadAccessTemplates
+    - *AdminCreateAccessWorkflows
+    - *AdminReadAccessWorkflows
+    - *AdminUpdateAccessWorkflows
+    - *AdminReadAccessRequests
+    - *AdminReadAccessStages
+    - *AdminReadAccessActions
+    - *AdminCreateAccessActions
+role2: &ApprovalRequesterRole
+  name: Approval Requester
+  system: true
+  version: 3
+  description: An Approval requester roles grants read and create permissions
+  access:
+    - *RequesterCreateAccessRequests
+    - *RequesterReadAccessRequests
+role3: &ApprovalApproverRole
+  name: Approval Approver
+  system: true
+  version: 3
+  description: An Approval approver roles grants read and create permissions
+  access:
+    - *ApproverReadAccessRequests
+    - *ApproverReadAccessStages
+    - *ApproverReadAccessActions
+    - *ApproverCreateAccessActions
+group1: &ApprovalAdministratorsGroup
+  name: Approval Administrators
+  description: Approval Administrators have complete access to all objects in the Approval Service.
+group2: &ApprovalRequestersGroup
+  name: Approval Requesters
+  description: Approval Requesters have limited access to certain objects in the Approval Service.
+policy1: &ApprovalAdministratorPolicy
+  name: Approval Administrator
+  group: *ApprovalAdministratorsGroup
+  role: *ApprovalAdministratorRole
+  description: Policy for Approval Administrators who have complete access to all objects in the Approval Service.
+policy2: &ApprovalRequesterPolicy
+  name: Approval Requester
+  group: *ApprovalRequestersGroup
+  role: *ApprovalRequesterRole
+  description: Policy for Approval Requesters who can limit access to certain objects in the Approval Service
+roles:
+  - *ApprovalAdministratorRole
+  - *ApprovalRequesterRole
+  - *ApprovalApproverRole
+groups:
+  - *ApprovalAdministratorsGroup
+  - *ApprovalRequestersGroup
+policies:
+  - *ApprovalAdministratorPolicy
+  - *ApprovalRequesterPolicy

--- a/data/rbac_approval_seed.yml
+++ b/data/rbac_approval_seed.yml
@@ -47,7 +47,7 @@ access64: &ApproverReadAccessRequests
 role1: &ApprovalAdministratorRole
   name: Approval Administrator
   system: true
-  version: 3
+  version: 1
   description: An Approval administrator roles grants create, read and update permissions
   access:
     - *AdminReadAccessTemplates
@@ -61,7 +61,7 @@ role1: &ApprovalAdministratorRole
 role2: &ApprovalApproverRole
   name: Approval Approver
   system: true
-  version: 3
+  version: 1
   description: An Approval approver roles grants read and create permissions
   access:
     - *ApproverReadAccessRequests

--- a/data/rbac_approval_seed.yml
+++ b/data/rbac_approval_seed.yml
@@ -20,19 +20,23 @@ access4: &AdminUpdateAccessWorkflows
   permission: approval:workflows:update
   resourceDefinitions:
           - *AdminResourceDefinition
-access5: &AdminReadAccessRequests
+access5: &AdminDestroyAccessWorkflows
+  permission: approval:workflows:destroy
+  resourceDefinitions:
+          - *AdminResourceDefinition
+access6: &AdminReadAccessRequests
   permission: approval:requests:read
   resourceDefinitions:
           - *AdminResourceDefinition
-access6: &AdminReadAccessStages
+access7: &AdminReadAccessStages
   permission: approval:stages:read
   resourceDefinitions:
           - *AdminResourceDefinition
-access7: &AdminReadAccessActions
+access8: &AdminReadAccessActions
   permission: approval:actions:read
   resourceDefinitions:
           - *AdminResourceDefinition
-access8: &AdminCreateAccessActions
+access9: &AdminCreateAccessActions
   permission: approval:actions:create
   resourceDefinitions:
           - *AdminResourceDefinition
@@ -48,12 +52,13 @@ role1: &ApprovalAdministratorRole
   name: Approval Administrator
   system: true
   version: 1
-  description: An Approval administrator roles grants create, read and update permissions
+  description: An Approval administrator role that grants create, read, update and destroy permissions
   access:
     - *AdminReadAccessTemplates
     - *AdminCreateAccessWorkflows
     - *AdminReadAccessWorkflows
     - *AdminUpdateAccessWorkflows
+    - *AdminDestroyAccessWorkflows
     - *AdminReadAccessRequests
     - *AdminReadAccessStages
     - *AdminReadAccessActions
@@ -62,24 +67,24 @@ role2: &ApprovalApproverRole
   name: Approval Approver
   system: true
   version: 1
-  description: An Approval approver roles grants read and create permissions
+  description: An Approval approver role that grants read and create permissions
   access:
     - *ApproverReadAccessRequests
     - *ApproverReadAccessStages
     - *ApproverReadAccessActions
     - *ApproverCreateAccessActions
-group1: &ApprovalAdministratorsGroup
+group1: &ApprovalAdministratorGroup
   name: Approval Administrators
   description: Approval Administrators have complete access to all objects in the Approval Service.
 policy1: &ApprovalAdministratorPolicy
   name: Approval Administrator
-  group: *ApprovalAdministratorsGroup
+  group: *ApprovalAdministratorGroup
   role: *ApprovalAdministratorRole
   description: Policy for Approval Administrators who have complete access to all objects in the Approval Service.
 roles:
   - *ApprovalAdministratorRole
   - *ApprovalApproverRole
 groups:
-  - *ApprovalAdministratorsGroup
+  - *ApprovalAdministratorGroup
 policies:
   - *ApprovalAdministratorPolicy

--- a/data/user.yml
+++ b/data/user.yml
@@ -1,0 +1,17 @@
+---
+identity:
+  account_number: '1111111'
+  type: User
+  user:
+    username: johndoe
+    email: johndoe@example.com
+    first_name: John
+    last_name: Doe
+    is_active: true
+    is_org_admin: false
+    is_internal: false
+    locale: en_US
+  internal:
+    org_id: '1111111'
+    auth_type: basic-auth
+    auth_time: 6300

--- a/lib/rbac/seed.rb
+++ b/lib/rbac/seed.rb
@@ -1,0 +1,129 @@
+require 'rbac-api-client'
+require 'pry'
+module RBAC
+  class Seed
+    def initialize(seed_file, user_file)
+      @acl_data = YAML.load_file(seed_file)
+      @request = create_request(user_file)
+    end
+
+    def process
+      ManageIQ::API::Common::Request.with_request(@request) do
+        create_groups
+        create_roles
+        create_policies
+      end
+    end
+
+    private
+
+    def create_groups
+      current = current_groups
+      names = current.collect(&:name)
+      group = RBACApiClient::Group.new
+      begin
+        RBAC::Service.call(RBACApiClient::GroupApi) do |api_instance|
+          @acl_data['groups'].each do |grp|
+            next if names.include?(grp['name'])
+            Rails.logger.info("Creating #{grp['name']}")
+            group.name = grp['name']
+            group.description = grp['description']
+            api_instance.create_group(group)
+          end
+        end
+      rescue RBACApiClient::ApiError => e
+        Rails.logger.error("Exception when calling GroupApi->create_group: #{e}")
+        raise
+      end
+    end
+
+    def current_groups
+      RBAC::Service.call(RBACApiClient::GroupApi) do |api|
+        RBAC::Service.paginate(api, :list_groups,  {}).to_a
+      end
+    end
+
+    def create_roles
+      current = current_roles
+      names = current.collect(&:name)
+      role_in = RBACApiClient::RoleIn.new
+      begin
+        RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
+          @acl_data['roles'].each do |role|
+            next if names.include?(role['name'])
+            role_in.name = role['name']
+            role_in.access = []
+            role['access'].each do |obj|
+              access = RBACApiClient::Access.new
+              access.permission = obj['permission']
+              access.resource_definitions = create_rds(obj)
+              role_in.access << access
+            end
+            api_instance.create_roles(role_in)
+          end
+        end
+      rescue RBACApiClient::ApiError => e
+        Rails.logger.error("Exception when calling RoleApi->create_roles: #{e}")
+        raise
+      end
+    end
+
+    def create_rds(obj)
+      obj.fetch('resource_definitions', []).collect do |item|
+        RBACApiClient::ResourceDefinition.new.tap do |rd|
+          rd.attribute_filter = RBACApiClient::ResourceDefinitionFilter.new.tap do |rdf|
+            rdf.key = item['attribute_filter']['key']
+            rdf.value = item['attribute_filter']['value']
+            rdf.operation = item['attribute_filter']['operation']
+          end
+        end
+      end
+    end
+
+    def current_roles
+      RBAC::Service.call(RBACApiClient::RoleApi) do |api|
+        RBAC::Service.paginate(api, :list_roles, {}).to_a
+      end
+    end
+
+    def create_policies
+      names = current_policies.collect(&:name)
+      groups = current_groups
+      roles = current_roles
+      policy_in = RBACApiClient::PolicyIn.new
+      begin
+        RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
+          @acl_data['policies'].each do |policy|
+            next if names.include?(policy['name'])
+            policy_in.name = policy['name']
+            policy_in.description = policy['description']
+            policy_in.group = find_uuid('Group', groups, policy['group']['name'])
+            policy_in.roles = [find_uuid('Role', roles, policy['role']['name'])]
+            api_instance.create_policies(policy_in)
+          end
+        end
+      rescue RBACApiClient::ApiError => e
+        Rails.logger.error("Exception when calling PolicyApi->create_policies: #{e}")
+        raise
+      end
+    end
+
+    def current_policies
+      RBAC::Service.call(RBACApiClient::PolicyApi) do |api|
+        RBAC::Service.paginate(api, :list_policies, {}).to_a
+      end
+    end
+
+    def find_uuid(type, data, name)
+      result = data.detect { |item| item.name == name }
+      raise "#{type} #{name} not found in RBAC service" unless result
+      result.uuid
+    end
+
+    def create_request(user_file)
+      raise "File #{user_file} not found" unless File.exist?(user_file)
+      user = YAML.load_file(user_file)
+      {:headers => {'x-rh-identity' => Base64.strict_encode64(user.to_json)}, :original_url => '/'}
+    end
+  end
+end

--- a/lib/rbac/seed.rb
+++ b/lib/rbac/seed.rb
@@ -1,5 +1,4 @@
 require 'rbac-api-client'
-require 'pry'
 module RBAC
   class Seed
     def initialize(seed_file, user_file)
@@ -25,6 +24,7 @@ module RBAC
         RBAC::Service.call(RBACApiClient::GroupApi) do |api_instance|
           @acl_data['groups'].each do |grp|
             next if names.include?(grp['name'])
+
             Rails.logger.info("Creating #{grp['name']}")
             group.name = grp['name']
             group.description = grp['description']
@@ -51,6 +51,7 @@ module RBAC
         RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
           @acl_data['roles'].each do |role|
             next if names.include?(role['name'])
+
             role_in.name = role['name']
             role_in.access = []
             role['access'].each do |obj|
@@ -95,6 +96,7 @@ module RBAC
         RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
           @acl_data['policies'].each do |policy|
             next if names.include?(policy['name'])
+
             policy_in.name = policy['name']
             policy_in.description = policy['description']
             policy_in.group = find_uuid('Group', groups, policy['group']['name'])
@@ -117,11 +119,13 @@ module RBAC
     def find_uuid(type, data, name)
       result = data.detect { |item| item.name == name }
       raise "#{type} #{name} not found in RBAC service" unless result
+
       result.uuid
     end
 
     def create_request(user_file)
       raise "File #{user_file} not found" unless File.exist?(user_file)
+
       user = YAML.load_file(user_file)
       {:headers => {'x-rh-identity' => Base64.strict_encode64(user.to_json)}, :original_url => '/'}
     end

--- a/lib/tasks/seed_rbac_data.rake
+++ b/lib/tasks/seed_rbac_data.rake
@@ -5,6 +5,7 @@ namespace :approval do
   task :seed_rbac_data => :environment do
     raise "Please provide a seed yaml file" unless ENV['SEED_FILE']
     raise "Please provide a user yaml file" unless ENV['USER_FILE']
+
     obj = RBAC::Seed.new(ENV['SEED_FILE'], ENV['USER_FILE'])
     obj.process
   end

--- a/lib/tasks/seed_rbac_data.rake
+++ b/lib/tasks/seed_rbac_data.rake
@@ -1,0 +1,11 @@
+require 'rake'
+
+namespace :approval do
+  desc "Seed RBAC data given a seed yaml file and an user yaml file"
+  task :seed_rbac_data => :environment do
+    raise "Please provide a seed yaml file" unless ENV['SEED_FILE']
+    raise "Please provide a user yaml file" unless ENV['USER_FILE']
+    obj = RBAC::Seed.new(ENV['SEED_FILE'], ENV['USER_FILE'])
+    obj.process
+  end
+end


### PR DESCRIPTION
This is the third phase to enable RBAC support in Approval service:

1. `rbac_approval_seed.yml` lists out all needed roles/acls/groups/policies for approval service; 
2. `rbac_approval_seed.yml` is also used to preconfigure RBAC environment (https://github.com/RedHatInsights/insights-rbac/pull/95);
3. provided a rake task to setup local RBAC environments;