### PR TITLE
Add ability to query for default workflow

### DIFF
--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -9,9 +9,12 @@ module Api
       end
 
       def show
-        workflow = Workflow.find(params.require(:id))
-
-        json_response(workflow)
+        if params.require(:id).to_s == "default"
+          json_response(Workflow.default_workflow)
+        else
+          workflow = Workflow.find(params.require(:id))
+          json_response(workflow)
+        end
       end
 
       def index

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -915,6 +915,43 @@
                     }
                 }
             }
+        },
+        "/workflows/default": {
+            "get": {
+                "tags": [
+                    "Workflow"
+                ],
+                "summary": "Return the default approval workflow",
+                "description": "Return the default approval workflow",
+                "operationId": "showDefaultWorkflow",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkflowOut"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/400BadRequestResponse"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/401UnauthorizedResponse"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/403ForbiddenResponse"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/404NotFoundResponse"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/422UnprocessableEntityResponse"
+                    }
+                }
+            }
         }
     },
     "security": [

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -93,6 +93,18 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
         expect(response.body).to match(/Couldn't find Workflow/)
       end
     end
+
+    context 'when querying for the default workflow' do
+      before { Workflow.seed }
+      after { Workflow.instance_variable_set(:@default_workflow, nil) }
+
+      it 'returns the default workflow' do
+        get "#{api_version}/workflows/default", :headers => request_header
+
+        expect(response).to have_http_status(:ok)
+        expect(json["id"]).to eq Workflow.default_workflow.id.to_s
+      end
+    end
   end
 
   # Test suite for POST /templates/:template_id/workflows
@@ -171,14 +183,11 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
   end
 
   describe 'DELETE /workflows/:id of default workflow' do
-    before do
-      Workflow.seed
-      delete "#{api_version}/workflows/#{Workflow.default_workflow.id}", :headers => request_header
-    end
-
+    before { Workflow.seed }
     after { Workflow.instance_variable_set(:@default_workflow, nil) }
 
     it 'returns status code 403' do
+      delete "#{api_version}/workflows/#{Workflow.default_workflow.id}", :headers => request_header
       expect(response).to have_http_status(403)
     end
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-535

For the catalog we need the ability to query for the default workflow due to the fact that when one isn't selected it just kind of sits in limbo. 

This will be used on the catalog tenant settings side as well as in the future when we have validation on the approval workflow the user selects.