### PR TITLE
Added services to create RBAC roles based on workflow's groups

### DIFF
--- a/app/controllers/api/v1x0/workflows_controller.rb
+++ b/app/controllers/api/v1x0/workflows_controller.rb
@@ -38,7 +38,7 @@ module Api
 
       def update
         workflow = Workflow.find(params.require(:id))
-        workflow.update(workflow_params)
+        WorkflowUpdateService.new(workflow.id).update(workflow_params)
 
         json_response(workflow)
       end

--- a/app/services/access_process_service.rb
+++ b/app/services/access_process_service.rb
@@ -2,7 +2,7 @@ class AccessProcessService
   include RBAC::Permissions
 
   def initialize(opts = {})
-    @app_name = opts[:app_name] || 'approval'
+    @app_name = ENV["APP_NAME"] || 'approval'
     @prefix = opts[:role_prefix] || "#{@app_name}-group-"
     @acls = RBAC::ACLS.new
     @roles = RBAC::Roles.new(@prefix)

--- a/app/services/access_process_service.rb
+++ b/app/services/access_process_service.rb
@@ -6,7 +6,24 @@ class AccessProcessService
     @prefix = opts[:role_prefix] || "#{@app_name}-group-"
     @acls = RBAC::ACLS.new
     @roles = RBAC::Roles.new(@prefix)
+    @policies = RBAC::Policies.new(@prefix)
   end
+
+  def add_resource_to_groups(resource_id, group_refs, permissions = [WORKFLOW_APPROVE_PERMISSION])
+    group_refs.each do |uuid|
+      name = "#{@prefix}#{uuid}"
+      update_or_create_role(name, resource_id, permissions)
+    end
+  end
+
+  def remove_resource_from_groups(resource_id, group_refs, permissions = [WORKFLOW_APPROVE_PERMISSION])
+    group_refs.each do |uuid|
+      name = "#{@prefix}#{uuid}"
+      remove_acls(name, resource_id, permissions)
+    end
+  end
+
+  private
 
   # Add access control lists to the role for group
   def add_acls(name, resource_id, permissions)
@@ -16,14 +33,14 @@ class AccessProcessService
     add_role_acls(role, resource_id, permissions)
   end
 
-  def remove_acls(name, resource_id, permissions = [WORKFLOW_APPROVE_PERMISSION])
+  def remove_acls(name, resource_id, permissions)
     role = find_role(name)
     raise Exceptions::RBACError("Role [#{name}] does not exist!") unless role
 
     remove_acls_or_delete_role(role, resource_id, permissions)
   end
 
-  def update_or_create_role(name, resource_id, permissions = [WORKFLOW_APPROVE_PERMISSION])
+  def update_or_create_role(name, resource_id, permissions)
     role = find_role(name)
 
     role ? add_role_acls(role, resource_id, permissions) : create_role(name, resource_id, permissions)
@@ -33,32 +50,14 @@ class AccessProcessService
     @roles.find(name)
   end
 
-  def add_resource_to_groups(resource_id, group_refs)
-    group_refs.each do |uuid|
-      name = "#{@prefix}#{uuid}"
-      update_or_create_role(name, resource_id)
-    end
-  end
-
-  def remove_resource_from_groups(resource_id, group_refs)
-    group_refs.each do |uuid|
-      name = "#{@prefix}#{uuid}"
-      remove_acls(name, resource_id)
-    end
-  end
-
-  private
-
   def create_role(name, resource_id, permissions)
     acls = @acls.create(resource_id, permissions)
-    role = @roles.add(name, acls)
-
-    add_policy(name, role.uuid)
-
-    role
+    @roles.add(name, acls).tap do |role|
+      @policies.add_policy(name, role.uuid)
+    end
   end
 
-  def add_role_acls(role, resource_id, permissions = [WORKFLOW_APPROVE_PERMISSION])
+  def add_role_acls(role, resource_id, permissions)
     role.access = @acls.add(role.access, resource_id, permissions)
     @roles.update(role)
   end
@@ -67,29 +66,10 @@ class AccessProcessService
     role.access = @acls.remove(role.access, resource_id, permissions)
 
     if @acls.resource_defintions_empty?(role.access, WORKFLOW_APPROVE_PERMISSION)
-      delete_policy(role)
+      @policies.delete_policy(role)
       @roles.delete(role)
     else
       @roles.update(role)
-    end
-  end
-
-  def add_policy(name, role_uuid)
-    RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
-      policy_in = RBACApiClient::PolicyIn.new
-      policy_in.name = name
-      policy_in.description = 'Approval Policy'
-      policy_in.group = name.split('group-')[1]
-      policy_in.roles = [role_uuid]
-      api_instance.create_policies(policy_in)
-    end
-  end
-
-  def delete_policy(role)
-    RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
-      RBAC::Service.paginate(api_instance, :list_policies, :name => @prefix).each do |policy|
-        api_instance.delete_policy(policy.uuid) if policy.roles.pluck(:uuid).include?(role.uuid)
-      end
     end
   end
 end

--- a/app/services/access_process_service.rb
+++ b/app/services/access_process_service.rb
@@ -1,0 +1,95 @@
+class AccessProcessService
+  include RBAC::Permissions
+
+  def initialize(opts = {})
+    @app_name = opts[:app_name] || 'approval'
+    @prefix = opts[:role_prefix] || "#{@app_name}-group-"
+    @acls = RBAC::ACLS.new
+    @roles = RBAC::Roles.new(@prefix)
+  end
+
+  # Add access control lists to the role for group
+  def add_acls(name, resource_id, permissions)
+    role = find_role(name)
+    raise Exceptions::RBACError("Role [#{name}] does not exist!") unless role
+
+    add_role_acls(role, resource_id, permissions)
+  end
+
+  def remove_acls(name, resource_id, permissions = [WORKFLOW_APPROVE_PERMISSION])
+    role = find_role(name)
+    raise Exceptions::RBACError("Role [#{name}] does not exist!") unless role
+
+    remove_acls_or_delete_role(role, resource_id, permissions)
+  end
+
+  def update_or_create_role(name, resource_id, permissions = [WORKFLOW_APPROVE_PERMISSION])
+    role = find_role(name)
+
+    role ? add_role_acls(role, resource_id, permissions) : create_role(name, resource_id, permissions)
+  end
+
+  def find_role(name)
+    @roles.find(name)
+  end
+
+  def add_resource_to_groups(resource_id, group_refs)
+    group_refs.each do |uuid|
+      name = "#{@prefix}#{uuid}"
+      update_or_create_role(name, resource_id)
+    end
+  end
+
+  def remove_resource_from_groups(resource_id, group_refs)
+    group_refs.each do |uuid|
+      name = "#{@prefix}#{uuid}"
+      remove_acls(name, resource_id)
+    end
+  end
+
+  private
+
+  def create_role(name, resource_id, permissions)
+    acls = @acls.create(resource_id, permissions)
+    role = @roles.add(name, acls)
+
+    add_policy(name, role.uuid)
+
+    role
+  end
+
+  def add_role_acls(role, resource_id, permissions = [WORKFLOW_APPROVE_PERMISSION])
+    role.access = @acls.add(role.access, resource_id, permissions)
+    @roles.update(role)
+  end
+
+  def remove_acls_or_delete_role(role, resource_id, permissions)
+    role.access = @acls.remove(role.access, resource_id, permissions)
+
+    if @acls.resource_defintions_empty?(role.access, WORKFLOW_APPROVE_PERMISSION)
+      delete_policy(role)
+      @roles.delete(role)
+    else
+      @roles.update(role)
+    end
+  end
+
+  def add_policy(name, role_uuid)
+    RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
+      policy_in = RBACApiClient::PolicyIn.new
+      policy_in.name = name
+      policy_in.description = 'Approval Policy'
+      policy_in.group = name.split('group-')[1]
+      policy_in.roles = [role_uuid]
+      api_instance.create_policies(policy_in)
+    end
+  end
+
+  def delete_policy(role)
+    RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
+      RBAC::Service.paginate(api_instance, :list_policies, :name => @prefix).each do |policy|
+        api_instance.delete_policy(policy.uuid) if policy.roles.pluck(:uuid).include?(role.uuid)
+      end
+    end
+  end
+end

--- a/app/services/workflow_create_service.rb
+++ b/app/services/workflow_create_service.rb
@@ -6,6 +6,14 @@ class WorkflowCreateService
   end
 
   def create(options)
-    template.workflows.create!(options)
+    template.workflows.create!(options).tap do |workflow|
+      begin
+        AccessProcessService.new.add_resource_to_groups(workflow.id, options[:group_refs]) if options[:group_refs]
+      rescue Exceptions::RBACError => error
+        Rails.logger.error("Exception when creating workflow: #{error}")
+        workflow&.destroy!
+        raise error
+      end
+    end
   end
 end

--- a/app/services/workflow_update_service.rb
+++ b/app/services/workflow_update_service.rb
@@ -1,0 +1,23 @@
+class WorkflowUpdateService
+  attr_accessor :workflow
+
+  def initialize(workflow_id)
+    self.workflow = Workflow.find(workflow_id)
+  end
+
+  def update(options)
+    original_group_refs = workflow.group_refs
+    current_group_refs = options[:group_refs]
+
+    if current_group_refs
+      removed_group_refs = original_group_refs - current_group_refs
+      added_group_refs = current_group_refs - original_group_refs
+
+      aps = AccessProcessService.new
+      aps.add_resource_to_groups(workflow.id, added_group_refs) if added_group_refs.any?
+      aps.remove_resource_from_groups(workflow.id, removed_group_refs) if removed_group_refs.any?
+    end
+
+    workflow.update!(options)
+  end
+end

--- a/lib/rbac/policies.rb
+++ b/lib/rbac/policies.rb
@@ -1,0 +1,27 @@
+module RBAC
+  class Policies
+    def initialize(prefix)
+      @prefix = prefix
+    end
+
+    def add_policy(name, role_uuid)
+      RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
+        policy_in = RBACApiClient::PolicyIn.new
+        policy_in.name = name
+        policy_in.description = 'Approval Policy'
+        policy_in.group = name.split('group-')[1]
+        policy_in.roles = [role_uuid]
+        api_instance.create_policies(policy_in)
+      end
+    end
+
+    # delete all policies that contains the role.
+    def delete_policy(role)
+      RBAC::Service.call(RBACApiClient::PolicyApi) do |api_instance|
+        RBAC::Service.paginate(api_instance, :list_policies, :name => @prefix).each do |policy|
+          api_instance.delete_policy(policy.uuid) if policy.roles.map(&:uuid).include?(role.uuid)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/v1.0/workflows_controller_spec.rb
+++ b/spec/controllers/v1.0/workflows_controller_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
     let(:group_refs) { %w[990 991 992] }
 
     let(:valid_attributes) { { :name => 'Visit Narnia', :description => 'workflow_valid', :group_refs => group_refs } }
+    let(:aps) { instance_double(AccessProcessService) }
+
+    before do
+      allow(AccessProcessService).to receive(:new).and_return(aps)
+      allow(aps).to receive(:add_resource_to_groups)
+    end
 
     context 'when request attributes are valid' do
       before { post "#{api_version}/templates/#{template_id}/workflows", :params => valid_attributes, :headers => request_header }
@@ -124,9 +130,17 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
 
   # Test suite for PATCH /workflows/:id
   describe 'PATCH /workflows/:id' do
-    let(:valid_attributes) { { :name => 'Mozart' } }
+    let(:valid_attributes) { { :name => 'Mozart', :group_refs => %w[999] } }
 
-    before { patch "#{api_version}/workflows/#{id}", :params => valid_attributes, :headers => request_header }
+    let(:aps) { instance_double(AccessProcessService) }
+
+    before do
+      allow(AccessProcessService).to receive(:new).and_return(aps)
+      allow(aps).to receive(:add_resource_to_groups)
+      allow(aps).to receive(:remove_resource_from_groups)
+
+      patch "#{api_version}/workflows/#{id}", :params => valid_attributes, :headers => request_header
+    end
 
     context 'when item exists' do
       it 'returns status code 200' do
@@ -136,6 +150,7 @@ RSpec.describe Api::V1x0::WorkflowsController, :type => :request do
       it 'updates the item' do
         updated_item = Workflow.find(id)
         expect(updated_item.name).to match(/Mozart/)
+        expect(updated_item.group_refs).to eq(%w[999])
       end
     end
 

--- a/spec/services/access_process_service_spec.rb
+++ b/spec/services/access_process_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AccessProcessService do
     allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1])
     allow(api_instance).to receive(:get_role).with(role1.uuid).and_return(role1_detail)
 
-    role = subject.find_role("approval-group-#{group1.uuid}")
+    role = subject.send(:find_role, "approval-group-#{group1.uuid}")
 
     expect(role.name).to eq(role1.name)
   end

--- a/spec/services/access_process_service_spec.rb
+++ b/spec/services/access_process_service_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe AccessProcessService do
+  let(:subject) { described_class.new }
+  let(:api_instance) { double }
+  let(:rs_class) { class_double("RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'group1', :uuid => "123") }
+  let(:role1) { instance_double(RBACApiClient::RoleOut, :name => "approval-group-#{group1.uuid}", :uuid => "67899") }
+  let(:access1) { instance_double(RBACApiClient::Access, :permission => "approval:actions:read", :resource_definitions => []) }
+  let(:role1_detail) { instance_double(RBACApiClient::RoleWithAccess, :name => role1.name, :uuid => role1.uuid, :access => [access1]) }
+  let(:pagination_options) { { :limit => 100, :name => "approval-group-" } }
+
+  before do
+    allow(rs_class).to receive(:call).with(RBACApiClient::AccessApi).and_yield(api_instance)
+    allow(rs_class).to receive(:call).with(RBACApiClient::RoleApi).and_yield(api_instance)
+    allow(rs_class).to receive(:call).with(RBACApiClient::PolicyApi).and_yield(api_instance)
+  end
+
+  it "#find_role" do
+    allow(RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1])
+    allow(api_instance).to receive(:get_role).with(role1.uuid).and_return(role1_detail)
+
+    role = subject.find_role("approval-group-#{group1.uuid}")
+
+    expect(role.name).to eq(role1.name)
+  end
+end

--- a/spec/services/workflow_create_service_spec.rb
+++ b/spec/services/workflow_create_service_spec.rb
@@ -1,9 +1,15 @@
 RSpec.describe WorkflowCreateService do
   let(:template) { create(:template) }
   let(:group_refs) { %w[991 992 993] }
+  let(:aps) { instance_double(AccessProcessService) }
+
   subject { described_class.new(template.id) }
 
   context 'create workflow' do
+    before do
+      allow(AccessProcessService).to receive(:new).and_return(aps)
+      allow(aps).to receive(:add_resource_to_groups)
+    end
     it 'create a workflow with valid group ids' do
       workflow = subject.create(:name => 'workflow_1', :description => 'workflow with valid groups', :group_refs => group_refs, :template_id => template.id)
       workflow.reload

--- a/spec/services/workflow_update_service_spec.rb
+++ b/spec/services/workflow_update_service_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe WorkflowUpdateService do
+  let(:workflow) { create(:workflow, :group_refs => [990, 991]) }
+  let(:aps) { instance_double(AccessProcessService) }
+
+  subject { described_class.new(workflow.id) }
+
+  context 'when update' do
+    before do
+      allow(AccessProcessService).to receive(:new).and_return(aps)
+      allow(aps).to receive(:add_resource_to_groups)
+      allow(aps).to receive(:remove_resource_from_groups)
+    end
+
+    it 'with group_refs' do
+      subject.update(:group_refs => [999])
+      workflow.reload
+      expect(workflow.group_refs).to eq([999])
+    end
+  end
+end


### PR DESCRIPTION
This is the fourth PR to enable RBAC support in Approval service:

Create or update RBAC roles when a workflow with groups information is created or updated.