### PR TITLE
Corrected return code for Action API with invalid content

### DIFF
--- a/app/controllers/api/v1x0/stageaction_controller.rb
+++ b/app/controllers/api/v1x0/stageaction_controller.rb
@@ -6,9 +6,14 @@ module Api
 
       protect_from_forgery :with => :exception, :prepend => true
 
-      rescue_from Exceptions::RBACError, Exceptions::ApprovalError, URI::InvalidURIError, ArgumentError do |e|
+      rescue_from Exceptions::RBACError, URI::InvalidURIError, ArgumentError do |e|
         response.body = e.message
         render :status => :internal_server_error, :action => :result
+      end
+
+      rescue_from Exceptions::ApprovalError do |e|
+        response.body = e.message
+        render :status => :bad_request, :action => :result
       end
 
       rescue_from ActionController::ParameterMissing do |_e|

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -19,7 +19,7 @@ module ExceptionHandler
       json_response({ :message => e.message }, :forbidden)
     end
 
-    rescue_from Exceptions::UserError do |e|
+    rescue_from Exceptions::UserError, Exceptions::ApprovalError do |e|
       json_response({ :message => e.message }, :bad_request)
     end
 


### PR DESCRIPTION
Changed return code to 400 (bad request) error code when posting an action with invalid content:
https://projects.engineering.redhat.com/browse/SSP-502