### PR TITLE
Added scope option when listing roles

### DIFF
--- a/app/services/access_process_service.rb
+++ b/app/services/access_process_service.rb
@@ -1,14 +1,16 @@
 class AccessProcessService
   include RBAC::Permissions
 
+  # Need to call as org admin
   def initialize(opts = {})
     @app_name = ENV["APP_NAME"] || 'approval'
     @prefix = opts[:role_prefix] || "#{@app_name}-group-"
     @acls = RBAC::ACLS.new
-    @roles = RBAC::Roles.new
+    @roles = RBAC::Roles.new(@prefix, 'account')
     @policies = RBAC::Policies.new(@prefix)
   end
 
+  # Need to call as org admin
   def add_resource_to_groups(resource_id, group_refs, permissions = [WORKFLOW_APPROVE_PERMISSION])
     group_refs.each do |uuid|
       name = "#{@prefix}#{uuid}"
@@ -16,6 +18,7 @@ class AccessProcessService
     end
   end
 
+  # Need to call as org admin
   def remove_resource_from_groups(resource_id, group_refs, permissions = [WORKFLOW_APPROVE_PERMISSION])
     group_refs.each do |uuid|
       name = "#{@prefix}#{uuid}"

--- a/lib/rbac/roles.rb
+++ b/lib/rbac/roles.rb
@@ -2,9 +2,9 @@ module RBAC
   class Roles
     attr_reader :roles
 
-    def initialize(prefix = nil)
+    def initialize(prefix = nil, scope = 'principal')
       @roles = {}
-      load(prefix)
+      load(prefix, scope)
     end
 
     def find(name)
@@ -44,8 +44,8 @@ module RBAC
 
     private
 
-    def load(prefix)
-      opts = { :scope => 'principal', :name => prefix, :limit => 500 }
+    def load(prefix, scope)
+      opts = { :scope => scope, :name => prefix, :limit => 500 }
       RBAC::Service.call(RBACApiClient::RoleApi) do |api_instance|
         RBAC::Service.paginate(api_instance, :list_roles, opts).each do |role|
           @roles[role.name] = role.uuid


### PR DESCRIPTION
Added scope option when initializing RBAC roles for two use cases:
1. use `:scope => 'principal'` when checking the roles for user;
2. use `:scope => 'account'` when creating approval roles for groups if needs;

https://projects.engineering.redhat.com/browse/SSP-776