### PR TITLE
Allow admin/approver to use requester/requests endpoint

### DIFF
--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -45,13 +45,13 @@ module Api
         # for admin endpoints
         return relation unless ids
 
-        Rails.logger.info("Accessible request ids: #{ids}")
+        Rails.logger.info("Accessible #{relation.model.table_name} ids: #{ids}")
 
         relation.where(:id => ids)
       end
 
       def right_path?
-        (approver? && approver_endpoint?) || (admin? && admin_endpoint?) || (requester_endpoint? && !admin? && !approver?)
+        (approver? && approver_endpoint?) || (admin? && admin_endpoint?) || requester_endpoint?
       end
 
       def admin_endpoint?

--- a/spec/controllers/v1.0/requests_controller_spec.rb
+++ b/spec/controllers/v1.0/requests_controller_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
         allow(roles_obj).to receive(:roles).and_return([admin_role])
         get "#{api_version}/requester/requests", :headers => default_headers
 
-        expect(response).to have_http_status(403)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -255,7 +255,7 @@ RSpec.describe Api::V1x0::RequestsController, :type => :request do
         allow(roles_obj).to receive(:roles).and_return([approver_role])
         get "#{api_version}/requester/requests", :headers => default_headers
 
-        expect(response).to have_http_status(403)
+        expect(response).to have_http_status(200)
       end
     end
 


### PR DESCRIPTION
Both `admin` and `approver` can be a regular requester. Changed to allow them to use endpoint `requester/requests` 