### PR TITLE
Remove persona specific endpoint and take persona in header

### DIFF
--- a/app/controllers/api/v1x0/requests_controller.rb
+++ b/app/controllers/api/v1x0/requests_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Mixins::IndexMixin
       include Mixins::RBACMixin
 
+      PERSONA_HEADER    = 'x-rh-persona'.freeze
+      PERSONA_ADMIN     = 'approval/admin'.freeze
+      PERSONA_APPROVER  = 'approval/approver'.freeze
+      PERSONA_REQUESTER = 'approval/requester'.freeze
+
       before_action :read_access_check, :only => %i[show]
       before_action :create_access_check, :only => %i[create]
 
@@ -34,36 +39,25 @@ module Api
       end
 
       def rbac_scope(relation)
-        raise Exceptions::NotAuthorizedError, "Current role cannot access #{request.path}" unless right_path?
+        ids =
+          case ManageIQ::API::Common::Request.current.headers[PERSONA_HEADER]
+          when PERSONA_ADMIN
+            raise Exceptions::NotAuthorizedError, "No permission to access the complete list of requests" unless admin?
+          when PERSONA_APPROVER
+            raise Exceptions::NotAuthorizedError, "No permission to access requests assigned to approvers" unless approver?
+            approver_id_list(relation.model.table_name)
+          when PERSONA_REQUESTER, nil
+            owner_id_list(relation.model.table_name)
+          else
+            raise Exceptions::NotAuthorizedError, "Unknown persona"
+          end
 
-        ids = if approver_endpoint?
-                approver_id_list(relation.model.table_name)
-              elsif requester_endpoint?
-                owner_id_list(relation.model.table_name)
-              end
-
-        # for admin endpoints
+        # for admin
         return relation unless ids
 
         Rails.logger.info("Accessible #{relation.model.table_name} ids: #{ids}")
 
         relation.where(:id => ids)
-      end
-
-      def right_path?
-        (approver? && approver_endpoint?) || (admin? && admin_endpoint?) || requester_endpoint?
-      end
-
-      def admin_endpoint?
-        request.path.end_with?("/admin/requests") || (request.path.end_with?("/requests") && !requester_endpoint? && !approver_endpoint?)
-      end
-
-      def requester_endpoint?
-        request.path.end_with?("/requester/requests")
-      end
-
-      def approver_endpoint?
-        request.path.end_with?("/approver/requests")
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,10 +30,6 @@ Rails.application.routes.draw do
         resources :actions, :only => [:create]
       end
 
-      get "/admin/requests", :action => 'index', :controller => 'requests'
-      get "/approver/requests", :action => 'index', :controller => 'requests'
-      get "/requester/requests", :action => 'index', :controller => 'requests'
-
       resources :workflows, :only => %i(index destroy update show) do
         resources :requests, :only => %i(create index)
       end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -220,178 +220,13 @@
                 "tags": [
                   "Request"
                 ],
-                "summary": "Obsoleted. Replaced by /admin/requests",
-                "description": "Return an array of requests",
+                "summary": "Return an array of approval requests, available to anyone",
+                "description": "Return an array of requests. The result depends on the x-rh-persona header",
                 "operationId": "listRequests",
                 "parameters": [
                     {
-                        "$ref": "#/components/parameters/limit"
+                        "$ref": "#/components/parameters/persona"
                     },
-                    {
-                        "$ref": "#/components/parameters/offset"
-                    },
-                    {
-                        "$ref": "#/components/parameters/filter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "headers": {
-                            "X-total-count": {
-                                "description": "Total number of items",
-                                "schema": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/RequestOutCollection"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/400BadRequestResponse"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/401UnauthorizedResponse"
-                    },
-                    "403": {
-                        "$ref": "#/components/responses/403ForbiddenResponse"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/404NotFoundResponse"
-                    },
-                    "422": {
-                        "$ref": "#/components/responses/422UnprocessableEntityResponse"
-                    }
-                }
-            }
-        },
-        "/admin/requests": {
-            "get": {
-                "tags": [
-                  "Request"
-                ],
-                "summary": "Return an array of approval requests, only available for admin role",
-                "description": "Return an array of requests for admin role",
-                "operationId": "listRequestsByAdmin",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/components/parameters/offset"
-                    },
-                    {
-                        "$ref": "#/components/parameters/filter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "headers": {
-                            "X-total-count": {
-                                "description": "Total number of items",
-                                "schema": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/RequestOutCollection"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/400BadRequestResponse"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/401UnauthorizedResponse"
-                    },
-                    "403": {
-                        "$ref": "#/components/responses/403ForbiddenResponse"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/404NotFoundResponse"
-                    },
-                    "422": {
-                        "$ref": "#/components/responses/422UnprocessableEntityResponse"
-                    }
-                }
-            }
-        },
-        "/approver/requests": {
-            "get": {
-                "tags": [
-                  "Request"
-                ],
-                "summary": "Return an array of approval requests, only available for approver role",
-                "description": "Return an array of requests for an approver",
-                "operationId": "listRequestsByApprover",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/limit"
-                    },
-                    {
-                        "$ref": "#/components/parameters/offset"
-                    },
-                    {
-                        "$ref": "#/components/parameters/filter"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "headers": {
-                            "X-total-count": {
-                                "description": "Total number of items",
-                                "schema": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/RequestOutCollection"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/400BadRequestResponse"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/401UnauthorizedResponse"
-                    },
-                    "403": {
-                        "$ref": "#/components/responses/403ForbiddenResponse"
-                    },
-                    "404": {
-                        "$ref": "#/components/responses/404NotFoundResponse"
-                    },
-                    "422": {
-                        "$ref": "#/components/responses/422UnprocessableEntityResponse"
-                    }
-                }
-            }
-        },
-        "/requester/requests": {
-            "get": {
-                "tags": [
-                  "Request"
-                ],
-                "summary": "Return an array of approval requests, only available for regular requester",
-                "description": "Return an array of requests for a regular requester",
-                "operationId": "listRequestsByRequester",
-                "parameters": [
                     {
                         "$ref": "#/components/parameters/limit"
                     },
@@ -1228,6 +1063,16 @@
                 "explode": true,
                 "schema": {
                     "type": "object"
+                }
+            },
+            "persona": {
+                "in": "header",
+                "name": "x-rh-persona",
+                "description": "Current login user's persona",
+                "required": false,
+                "schema": {
+                    "type": "string",
+                    "enum": ["approval/admin", "approval/approver", "approval/requester"]
                 }
             }
         },


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-794

Since each login may have multiple personas, we introduced three persona specific endpoints for requests, namely
/admin/requests
/approver/requests
/requester/requests

However this causes problem for GraphQL query because the persona is not a built in attributes of requests. Now we decide to remove these endpoints and take the persona parameter from header. The mapping from old endpoint to new is as follows
/admin/requests -> /requests with header x-rh-persona=approval/admin
/approver/requests -> /requests with header x-rh-persona=approval/approver
/requester/requests -> /requests with header x-rh-persona=approval/requester

A request without header x-rh-persona is the same as approval/requester
A request with unknown x-rh-persona header gets return code 403

The persona header works with RBAC together. A mismatching of persona and RBAC role results in a return code 403.