### PR TITLE
Temporary allow regular user like BPM to create 'notify' action

### DIFF
--- a/app/controllers/api/v1x0/actions_controller.rb
+++ b/app/controllers/api/v1x0/actions_controller.rb
@@ -40,9 +40,11 @@ module Api
       #   admin:     can create all kinds of actions
       #   approver:  can not create 'cancel' action
       #   requester: can only create 'cancel' action
+      #     temporary allow bpm to create 'notify' action
       def validate_create_action
         operation = params[:operation]
-        valid_operation = admin? || (approver? && operation != Action::CANCEL_OPERATION) || (!admin? && !approver? && operation == Action::CANCEL_OPERATION)
+        valid_operation = admin? || (approver? && operation != Action::CANCEL_OPERATION) ||
+                          (!admin? && !approver? && [Action::CANCEL_OPERATION, Action::NOTIFY_OPERATION].include?(operation))
         raise Exceptions::NotAuthorizedError, "Not authorized to create [#{operation}] action " unless valid_operation
       end
 

--- a/spec/controllers/v1.0/actions_controller_spec.rb
+++ b/spec/controllers/v1.0/actions_controller_spec.rb
@@ -175,12 +175,12 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       it_behaves_like "validate_operation"
     end
 
-    context 'owner role for invalid operation notify' do
+    context 'owner role for valid operation notify' do
       let(:acls) { [] }
       let(:access_obj) { instance_double(RBAC::Access, :acl => acls) }
       let(:roles) { [] }
       let(:valid_attributes) { { :operation => 'notify', :processed_by => 'abcd' } }
-      let(:code) { 403 }
+      let(:code) { 201 }
 
       it_behaves_like "validate_operation"
     end
@@ -224,10 +224,10 @@ RSpec.describe Api::V1x0::ActionsController, :type => :request do
       let!(:stage2) { create(:stage, :state => Stage::FINISHED_STATE, :request => req, :tenant_id => tenant.id) }
       let(:valid_attributes) { { :operation => 'notify', :processed_by => 'abcd' } }
 
-      it 'returns status code 403' do
+      it 'returns status code 422' do
         post "#{api_version}/requests/#{req.id}/actions", :params => valid_attributes, :headers => default_headers, :as => :json
 
-        expect(response).to have_http_status(403)
+        expect(response).to have_http_status(422)
       end
     end
   end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-809

Notify is an action performed by system but under the context of requester. This is a temporary solution to allow regular user to add a `notifiy` action. We will come up a better solution for system to perform all needed actions.