### PR TITLE
Fix tag_link uniqueness validation

### DIFF
--- a/app/models/tag_link.rb
+++ b/app/models/tag_link.rb
@@ -3,5 +3,5 @@ class TagLink < ApplicationRecord
 
   belongs_to :workflow, :inverse_of => :tag_links
 
-  validates :tag_name, :uniqueness => { :scope => [:app_name, :object_type] }
+  validates :tag_name, :uniqueness => { :scope => [:app_name, :object_type, :tenant_id] }
 end

--- a/db/migrate/20191011161512_change_tag_links_index.rb
+++ b/db/migrate/20191011161512_change_tag_links_index.rb
@@ -1,0 +1,6 @@
+class ChangeTagLinksIndex < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :tag_links, [:app_name, :object_type, :tag_name]
+    add_index :tag_links, [:app_name, :object_type, :tag_name, :tenant_id], :unique => true, :name => 'index_tag_links_on_app_type_tag'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_102743) do
+ActiveRecord::Schema.define(version: 2019_10_11_161512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_102743) do
     t.string "tag_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["app_name", "object_type", "tag_name"], name: "index_tag_links_on_app_name_and_object_type_and_tag_name", unique: true
+    t.index ["app_name", "object_type", "tag_name", "tenant_id"], name: "index_tag_links_on_app_type_tag", unique: true
   end
 
   create_table "templates", force: :cascade do |t|

--- a/spec/models/tag_link_spec.rb
+++ b/spec/models/tag_link_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe TagLink, :type => :model do
+  let(:workflow) { create(:workflow) }
+  let(:a_tag) { {:workflow => workflow, :object_type => 'inventory', :app_name => 'topology', :tag_name => '/approval/workflows/abc'} }
+
+  it { should belong_to(:workflow) }
+
+  context 'duplicated tag link in different tenants' do
+    let(:tenant1) { create(:tenant) }
+    let(:tenant2) { create(:tenant) }
+
+    before { ActsAsTenant.with_tenant(tenant1) { described_class.create(a_tag) } }
+
+    it 'creates the same link in another tenant' do
+      ActsAsTenant.with_tenant(tenant2) do
+        expect { described_class.create!(a_tag) }.not_to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  context 'duplicated tag link in the same tenant' do
+    let(:tenant) { create(:tenant) }
+
+    before { ActsAsTenant.with_tenant(tenant) { described_class.create(a_tag) } }
+
+    it 'raises an error while attempting to create the same link' do
+      ActsAsTenant.with_tenant(tenant) do
+        expect { described_class.create!(a_tag) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Workflow, :type => :model do
 
   it { should belong_to(:template) }
   it { should have_many(:requests) }
+  it { should have_many(:tag_links) }
 
   it { should validate_presence_of(:name) }
 


### PR DESCRIPTION
The uniqueness validation should take tenant_id into consideration. ActsAsTenant does not automatically add the scope to validation.
