### PR TITLE
Schema and model change to add sequence to workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.5.4
+- 2.5.5
 addons:
   postgresql: '10'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.4.5
+- 2.5.4
 addons:
   postgresql: '10'
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
+gem 'acts_as_list',        '~> 1.0'
 gem 'acts_as_tenant'
 gem 'jbuilder',            '~> 2.0'
 gem 'manageiq-api-common', '~> 1.0', '>= 1.0.2'

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -1,6 +1,9 @@
 class Workflow < ApplicationRecord
   acts_as_tenant(:tenant, :has_global_records => true)
 
+  acts_as_list :scope => [:tenant_id], :column => 'sequence'
+  default_scope { order(:sequence => :asc) }
+
   belongs_to :template
   has_many :requests, -> { order(:id => :asc) }, :inverse_of => :workflow
   has_many :tag_links, :dependent => :destroy, :inverse_of => :workflow

--- a/db/migrate/20191014102030_add_sequence_to_workflows.rb
+++ b/db/migrate/20191014102030_add_sequence_to_workflows.rb
@@ -1,0 +1,5 @@
+class AddSequenceToWorkflows < ActiveRecord::Migration[5.2]
+  def change
+    add_column :workflows, :sequence, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_11_161512) do
+ActiveRecord::Schema.define(version: 2019_10_14_102030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,7 @@ ActiveRecord::Schema.define(version: 2019_10_11_161512) do
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.jsonb "group_refs", default: [], array: true
+    t.integer "sequence"
     t.index ["template_id"], name: "index_workflows_on_template_id"
     t.index ["tenant_id"], name: "index_workflows_on_tenant_id"
   end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -667,7 +667,7 @@
                   "Workflow"
                 ],
                 "summary": "Return all approval workflows, only available for admin",
-                "description": "Return all approval workflows",
+                "description": "Return all approval workflows in ascending sequence order",
                 "operationId": "listWorkflows",
                 "parameters": [
                     {
@@ -1393,6 +1393,10 @@
                     "description": {
                         "type": "string"
                     },
+                    "sequence": {
+                        "type": "integer",
+                         "description": "an indicator of the execution order for selected workflows"
+                    },
                     "group_refs": {
                         "type": "array",
                         "description": "Group reference ids associated with workflow",
@@ -1418,6 +1422,10 @@
                     },
                     "description": {
                         "type": "string"
+                    },
+                    "sequence": {
+                        "type": "integer",
+                        "description": "an indicator of the execution order for selected workflows"
                     },
                     "group_refs": {
                         "type": "array",

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -16,29 +16,25 @@ RSpec.describe Workflow, :type => :model do
     before { create_list(:workflow, 5) }
 
     it 'lists workflows in sequence ascending order' do
-      orders = Workflow.all.pluck(:sequence)
-      sorted_orders = orders.sort
-      expect(orders).to eq(sorted_orders)
+      orders = Workflow.pluck(:sequence)
+      expect(orders).to eq(orders.sort)
     end
 
     it 'places newly created workflow to the end of ascending list' do
-      old_last = Workflow.all.last
-      new_workflow = create(:workflow)
-      expect(new_workflow.sequence).to be > old_last.sequence
+      old_last = Workflow.last
+      expect(create(:workflow).sequence).to be > old_last.sequence
     end
 
     it 'moves up an workflow sequence' do
-      old_ids = Workflow.all.pluck(:id)
+      old_ids = Workflow.pluck(:id)
       Workflow.find(old_ids[3]).update(:sequence => Workflow.find(old_ids[1]).sequence)
-      new_ids = Workflow.all.pluck(:id)
-      expect(new_ids).to eq([old_ids[0], old_ids[3], old_ids[1], old_ids[2], old_ids[4]])
+      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[3], old_ids[1], old_ids[2], old_ids[4]])
     end
 
     it 'moves down an workflow sequence' do
-      old_ids = Workflow.all.pluck(:id)
+      old_ids = Workflow.pluck(:id)
       Workflow.find(old_ids[1]).update(:sequence => Workflow.find(old_ids[3]).sequence)
-      new_ids = Workflow.all.pluck(:id)
-      expect(new_ids).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[1], old_ids[4]])
+      expect(Workflow.pluck(:id)).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[1], old_ids[4]])
     end
   end
 

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -8,6 +8,40 @@ RSpec.describe Workflow, :type => :model do
 
   it { should validate_presence_of(:name) }
 
+  describe '#sequence' do
+    around(:each) do |example|
+      ActsAsTenant.with_tenant(tenant) { example.run }
+    end
+
+    before { create_list(:workflow, 5) }
+
+    it 'lists workflows in sequence ascending order' do
+      orders = Workflow.all.pluck(:sequence)
+      sorted_orders = orders.sort
+      expect(orders).to eq(sorted_orders)
+    end
+
+    it 'places newly created workflow to the end of ascending list' do
+      old_last = Workflow.all.last
+      new_workflow = create(:workflow)
+      expect(new_workflow.sequence).to be > old_last.sequence
+    end
+
+    it 'moves up an workflow sequence' do
+      old_ids = Workflow.all.pluck(:id)
+      Workflow.find(old_ids[3]).update(:sequence => Workflow.find(old_ids[1]).sequence)
+      new_ids = Workflow.all.pluck(:id)
+      expect(new_ids).to eq([old_ids[0], old_ids[3], old_ids[1], old_ids[2], old_ids[4]])
+    end
+
+    it 'moves down an workflow sequence' do
+      old_ids = Workflow.all.pluck(:id)
+      Workflow.find(old_ids[1]).update(:sequence => Workflow.find(old_ids[3]).sequence)
+      new_ids = Workflow.all.pluck(:id)
+      expect(new_ids).to eq([old_ids[0], old_ids[2], old_ids[3], old_ids[1], old_ids[4]])
+    end
+  end
+
   describe '.seed' do
     after { Workflow.instance_variable_set(:@default_workflow, nil) }
 


### PR DESCRIPTION
Backend support to enable workflow sequencing management per tenant using ActsAsList.

When a new workflow is created, the sequence is automatically assigned to the next available value if it is not provided by the caller.

Workflow update API allows the caller to directly update. No dedicated API and service class are needed.

When a workflow sequence is changed, all affected workflows' sequences will be automatically updated.