### PR TITLE
add workflow_unlink_service

### DIFF
--- a/app/services/workflow_link_service.rb
+++ b/app/services/workflow_link_service.rb
@@ -10,10 +10,6 @@ class WorkflowLinkService
     nil
   end
 
-  def unlink(tag_attrs)
-    TagLink.find_by(tag_link(tag_attrs)).try(:destroy)
-  end
-
   private
 
   def tag_link(tag_attrs)

--- a/app/services/workflow_unlink_service.rb
+++ b/app/services/workflow_unlink_service.rb
@@ -1,0 +1,13 @@
+class WorkflowUnlinkService
+  attr_accessor :workflow_id
+
+  def initialize(workflow_id = nil)
+    self.workflow_id = workflow_id
+  end
+
+  def unlink(tag_attrs)
+    # TODO: find linked tag and remove it from resource object's tag list
+
+    # Leave the tag link in the tag_links table!
+  end
+end

--- a/spec/services/workflow_link_service_spec.rb
+++ b/spec/services/workflow_link_service_spec.rb
@@ -19,19 +19,4 @@ RSpec.describe WorkflowLinkService do
       end
     end
   end
-
-  describe 'unlink' do
-    it 'removes an existing link' do
-      subject.link(a_tag)
-      expect(TagLink.count).to eq(1)
-
-      subject.unlink(a_tag)
-      expect(TagLink.count).to eq(0)
-    end
-
-    it 'is ok to remove a non-existing link' do
-      subject.unlink(a_tag)
-      expect(TagLink.count).to eq(0)
-    end
-  end
 end


### PR DESCRIPTION
Create a separate service class to do the unlinking. It does not delete the entry from `tag_links` table. Instead it should attempt to delete resolved tag name from the resource object (to be followed up by another PR).