### PR TITLE
Move content and context into a separate table and share with children

### DIFF
--- a/app/models/request_context.rb
+++ b/app/models/request_context.rb
@@ -1,0 +1,9 @@
+class RequestContext < ApplicationRecord
+  before_create :set_context
+
+  private
+
+  def set_context
+    self.context = ManageIQ::API::Common::Request.current.to_h
+  end
+end

--- a/app/services/request_create_service.rb
+++ b/app/services/request_create_service.rb
@@ -6,10 +6,9 @@ class RequestCreateService
   def create(options)
     requester = ManageIQ::API::Common::Request.current.user
     options = options.transform_keys(&:to_sym)
-    create_options = options.slice(:name, :description, :content).merge(
-      :state          => Request::PENDING_STATE,
-      :decision       => Request::UNDECIDED_STATUS,
-      :requester_name => "#{requester.first_name} #{requester.last_name}"
+    create_options = options.slice(:name, :description).merge(
+      :requester_name  => "#{requester.first_name} #{requester.last_name}",
+      :request_context => RequestContext.new(:content => options[:content])
     )
 
     self.workflows = WorkflowFindService.new.find_by_tag_resources(options[:tag_resources])

--- a/db/migrate/20191018142121_create_request_contexts.rb
+++ b/db/migrate/20191018142121_create_request_contexts.rb
@@ -1,0 +1,12 @@
+class CreateRequestContexts < ActiveRecord::Migration[5.1]
+  def change
+    create_table :request_contexts do |t|
+      t.jsonb :content
+      t.jsonb :context
+    end
+
+    add_column :requests, :request_context_id, :bigint
+    remove_column :requests, :content, :jsonb
+    remove_column :requests, :context, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_18_141212) do
+ActiveRecord::Schema.define(version: 2019_10_18_142121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,11 @@ ActiveRecord::Schema.define(version: 2019_10_18_141212) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "request_contexts", force: :cascade do |t|
+    t.jsonb "content"
+    t.jsonb "context"
+  end
+
   create_table "requests", force: :cascade do |t|
     t.string "requester_name"
     t.string "name"
@@ -41,15 +46,14 @@ ActiveRecord::Schema.define(version: 2019_10_18_141212) do
     t.string "state"
     t.string "decision"
     t.string "reason"
-    t.jsonb "content"
     t.bigint "workflow_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "tenant_id"
     t.string "process_ref"
-    t.jsonb "context"
     t.string "owner"
     t.bigint "parent_id"
+    t.bigint "request_context_id"
     t.index ["parent_id"], name: "index_requests_on_parent_id"
     t.index ["tenant_id"], name: "index_requests_on_tenant_id"
     t.index ["workflow_id"], name: "index_requests_on_workflow_id"

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -3,18 +3,18 @@ FactoryBot.define do
   factory :request do
     items = { Faker::Lorem.word   => Faker::Lorem.word,
              Faker::Lorem.word   => Faker::Lorem.word }
-    name           { Faker::Lorem.word }
-    requester_name { Faker::Lorem.word }
-    owner          { Faker::Lorem.word }
-    content        { JSON.generate(items) }
-    state          { :pending }
-    decision       { :undecided }
+    name            { Faker::Lorem.word }
+    requester_name  { Faker::Lorem.word }
+    owner           { Faker::Lorem.word }
+    request_context { RequestContext.new(:content => JSON.generate(items)) }
+    state           { :pending }
+    decision        { :undecided }
 
     workflow
 
     trait :with_context do
       after(:create) do |obj|
-        obj.update_attributes(:context => RequestSpecHelper.default_request_hash)
+        obj.request_context.update(:context => RequestSpecHelper.default_request_hash)
       end
     end
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe Request, type: :model do
+  it { should belong_to(:request_context) }
   it { should belong_to(:workflow) }
   it { should have_many(:stages) }
   it { should have_many(:children) }
 
   it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:content) }
 
   describe '#as_json' do
     subject { FactoryBot.create(:request, :stages => stages) }
@@ -89,6 +89,22 @@ RSpec.describe Request, type: :model do
         expect(subject.number_of_children).to eq(3)
         expect(subject.number_of_finished_children).to eq(1)
       end
+    end
+  end
+
+  describe '#create_child' do
+    subject { FactoryBot.create(:request) }
+    it 'creates a child' do
+      child = subject.create_child
+      expect(child).to have_attributes(
+        :name               => subject.name,
+        :description        => subject.description,
+        :request_context_id => subject.request_context_id,
+        :owner              => subject.owner,
+        :requester_name     => subject.requester_name,
+        :state              => Request::PENDING_STATE,
+        :decision           => Request::UNDECIDED_STATUS
+      )
     end
   end
 end


### PR DESCRIPTION
Move `content` and `context` into table `request_contexts`.
Share the same `request_context` when a child request is created.